### PR TITLE
Added parental kmer matrix and normalized by the parent kmer file size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,6 +239,7 @@ set(EXECUTABLES
         extract_haplotype_kmers
         extract_haplotype_kmers_count_parent_kmers
         get_path_lengths
+        phase_graph_components
         )
 
 foreach(FILENAME_PREFIX ${EXECUTABLES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,7 +269,6 @@ set(EXECUTABLES
         extract_haplotype_kmers
         extract_haplotype_kmers_count_parent_kmers
         get_path_lengths
-        phase_graph_components
         )
 
 foreach(FILENAME_PREFIX ${EXECUTABLES})

--- a/inc/kmer_unordered_set.hpp
+++ b/inc/kmer_unordered_set.hpp
@@ -26,23 +26,27 @@ class KmerSets {
 		// path to kmer parent files as input from command line
 		path hap1_kmer_fa_path;
 		path hap2_kmer_fa_path;
+		float num_hap1_kmers;
+		float num_hap2_kmers;
 		// component and haplotype 
 		int graph_component;
 		int component_haplotype;
 		static const int parent_hap1_int = 0; // hg03 paternal 
 		static const int parent_hap2_int = 1; // hg04 maternal
 		// < component,  [component_hap_path][parent_hap_int] >
-		map<int, int [2][2]> component_map;
+		map<int, float [2][2]> component_map;
 
 	/// Methods ///
 	public:
 		KmerSets();
-		KmerSets(path hap1_kmer_fa_path_arg, path hap2_kmer_fa_path_arg);
-		void load_file_into_unordered_set(path file_path, unordered_set <string>& set);
+		KmerSets(path hap1_kmer_fa_path_arg, path hap2_kmer_fa_path_args);
+		void load_file_into_unordered_set(path , unordered_set <string>& , string);
+		void get_size_of_kmer_file(path , string );
 		void get_parent_kmer_sets();
 		bool find_haplotype_kmer_set_count(string, unordered_set <string>);
 		void parse_path_string(string);
 		bool increment_parental_kmer_count(string, string );
+		void normalize_kmer_counts();
 		void print_component_parent_conf_matrix();
 };
 

--- a/inc/kmer_unordered_set.hpp
+++ b/inc/kmer_unordered_set.hpp
@@ -13,6 +13,8 @@ using ghc::filesystem::path;
 
 // Hashtable to implement a hashtable of kmers 
 
+namespace gfase {
+
 class KmerSets {
 	/// Attributes ///
 	private:
@@ -33,8 +35,10 @@ class KmerSets {
 		void load_file_into_unordered_set(path file_path, unordered_set <string>& set);
 		void get_parent_kmer_sets();
 		bool find_haplotype_kmer_set_count(unordered_set <string>);
-		bool find_haplotype_single_kmer_count(string child_kmer);
+		pair<bool,bool> find_haplotype_single_kmer_count(string child_kmer);
 
 };
+
+}
 
 #endif //GFASE_KMERSETS_HPP

--- a/inc/kmer_unordered_set.hpp
+++ b/inc/kmer_unordered_set.hpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <list>
 #include <string>
+#include <array>
 #include <map>
 #include <unordered_set>
 #include <fstream>
@@ -29,21 +30,21 @@ class KmerSets {
 		float num_hap1_kmers;
 		float num_hap2_kmers;
 		// component and haplotype 
-		int graph_component;
-		int component_haplotype;
-		static const int parent_hap1_int = 0; // hg03 paternal 
-		static const int parent_hap2_int = 1; // hg04 maternal
-		// < component,  [component_hap_path][parent_hap_int] >
-		map<int, float [2][2]> component_map;
+		size_t graph_component;
+		size_t component_haplotype;
+		static const size_t parent_hap1_index = 0; // hg03 paternal 
+		static const size_t parent_hap2_index = 1; // hg04 maternal
+		// < component,  [component_hap_path][parent_hap_index] >
+		map<size_t, array <array <float,2>, 2>> component_map;
 
 	/// Methods ///
 	public:
 		KmerSets();
 		KmerSets(path hap1_kmer_fa_path_arg, path hap2_kmer_fa_path_args);
-		void load_file_into_unordered_set(path , unordered_set <string>& , string);
-		void get_size_of_kmer_file(path , string );
+		void load_file_into_unordered_set(path , unordered_set <string>& );
+		float get_size_of_kmer_file(path);
 		void get_parent_kmer_sets();
-		bool find_haplotype_kmer_set_count(string, unordered_set <string>);
+		bool parental_kmer_count_for_kmer_set(string, unordered_set <string>);
 		void parse_path_string(string);
 		bool increment_parental_kmer_count(string, string );
 		void normalize_kmer_counts();

--- a/inc/kmer_unordered_set.hpp
+++ b/inc/kmer_unordered_set.hpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <list>
 #include <string>
+#include <map>
 #include <unordered_set>
 #include <fstream>
 #include "Filesystem.hpp"
@@ -15,6 +16,7 @@ using ghc::filesystem::path;
 
 namespace gfase {
 
+
 class KmerSets {
 	/// Attributes ///
 	private:
@@ -24,9 +26,13 @@ class KmerSets {
 		// path to kmer parent files as input from command line
 		path hap1_kmer_fa_path;
 		path hap2_kmer_fa_path;
-
-		int hap1_kmer_count;
-		int hap2_kmer_count;
+		// component and haplotype 
+		int graph_component;
+		int component_haplotype;
+		static const int parent_hap1_int = 0; // hg03 paternal 
+		static const int parent_hap2_int = 1; // hg04 maternal
+		// < component,  [component_hap_path][parent_hap_int] >
+		map<int, int [2][2]> component_map;
 
 	/// Methods ///
 	public:
@@ -34,9 +40,10 @@ class KmerSets {
 		KmerSets(path hap1_kmer_fa_path_arg, path hap2_kmer_fa_path_arg);
 		void load_file_into_unordered_set(path file_path, unordered_set <string>& set);
 		void get_parent_kmer_sets();
-		bool find_haplotype_kmer_set_count(unordered_set <string>);
-		pair<bool,bool> find_haplotype_single_kmer_count(string child_kmer);
-
+		bool find_haplotype_kmer_set_count(string, unordered_set <string>);
+		void parse_path_string(string);
+		bool increment_parental_kmer_count(string, string );
+		void print_component_parent_conf_matrix();
 };
 
 }

--- a/inc/kmer_unordered_set.hpp
+++ b/inc/kmer_unordered_set.hpp
@@ -41,12 +41,12 @@ class KmerSets {
 	public:
 		KmerSets();
 		KmerSets(path hap1_kmer_fa_path_arg, path hap2_kmer_fa_path_args);
-		void load_file_into_unordered_set(path , unordered_set <string>& );
 		float get_size_of_kmer_file(path);
+		void load_file_into_unordered_set(path , unordered_set <string>& );		
 		void get_parent_kmer_sets();
-		bool parental_kmer_count_for_kmer_set(string, unordered_set <string>);
 		void parse_path_string(string);
 		bool increment_parental_kmer_count(string, string );
+		bool increment_parental_kmer_count(string, unordered_set <string>);
 		void normalize_kmer_counts();
 		void print_component_parent_conf_matrix();
 };

--- a/inc/kmer_unordered_set.hpp
+++ b/inc/kmer_unordered_set.hpp
@@ -41,12 +41,12 @@ class KmerSets {
 	public:
 		KmerSets();
 		KmerSets(path hap1_kmer_fa_path_arg, path hap2_kmer_fa_path_args);
-		float get_size_of_kmer_file(path);
-		void load_file_into_unordered_set(path , unordered_set <string>& );		
+		float get_size_of_kmer_file(path file_path);
+		void load_file_into_unordered_set(path file_path, unordered_set <string>& set);		
 		void get_parent_kmer_sets();
-		void parse_path_string(string);
-		bool increment_parental_kmer_count(string, string );
-		bool increment_parental_kmer_count(string, unordered_set <string>);
+		void parse_path_string(string path_string);
+		bool increment_parental_kmer_count(string path_hap_string, string child_kmer);
+		bool increment_parental_kmer_count(string path_name, unordered_set <string> child_kmers);
 		void normalize_kmer_counts();
 		void print_component_parent_conf_matrix();
 };

--- a/src/executable/extract_haplotype_kmers_count_parent_kmers.cpp
+++ b/src/executable/extract_haplotype_kmers_count_parent_kmers.cpp
@@ -129,13 +129,17 @@ void extract_haplotype_kmers_from_gfa(path gfa_path, size_t k, path paternal_kme
 
     cerr << "Iterating path kmers..." << '\n';
 
+    cerr << " Number of (components?) in Graph: " << graph.get_path_count() << '\n';
+
     bool prev_has_diploid;
 
     // Iterate paths and for each node, collect kmers if node is only covered by one path
     graph.for_each_path_handle([&](const path_handle_t& p){
         cerr << ">" << graph.get_path_name(p) << '\n';
- 
+
         HaplotypePathKmer kmer(graph, p, k);
+
+        string component_path_string = graph.get_path_name(p);
 
         while (kmer.step()){
             if (kmer.has_diploid){
@@ -145,8 +149,7 @@ void extract_haplotype_kmers_from_gfa(path gfa_path, size_t k, path paternal_kme
                     kmer_string+=c;
                 }
                 // compare kmer to parental kmers
-                pair <bool,bool> hap1_hap2 = ks.find_haplotype_single_kmer_count(kmer_string);
-                cerr << " hap1: " << hap1_hap2.first << " hap2: " << hap1_hap2.second;
+                ks.increment_parental_kmer_count(component_path_string, kmer_string);
                 cerr << '\n'; 
 
             }
@@ -161,8 +164,9 @@ void extract_haplotype_kmers_from_gfa(path gfa_path, size_t k, path paternal_kme
             }
 
             prev_has_diploid = kmer.has_diploid;
-        }
+        }    
     });
+    ks.print_component_parent_conf_matrix();
 }
 
 

--- a/src/executable/extract_haplotype_kmers_count_parent_kmers.cpp
+++ b/src/executable/extract_haplotype_kmers_count_parent_kmers.cpp
@@ -145,12 +145,12 @@ void extract_haplotype_kmers_from_gfa(path gfa_path, size_t k, path paternal_kme
             if (kmer.has_diploid){
                 string kmer_string;
                 for (auto& c: kmer.sequence){
-                    cerr << c; 
+                    // cerr << c; 
                     kmer_string+=c;
                 }
                 // compare kmer to parental kmers
                 ks.increment_parental_kmer_count(component_path_string, kmer_string);
-                cerr << '\n'; 
+                // cerr << '\n'; 
 
             }
             else{

--- a/src/executable/extract_haplotype_kmers_count_parent_kmers.cpp
+++ b/src/executable/extract_haplotype_kmers_count_parent_kmers.cpp
@@ -166,6 +166,7 @@ void extract_haplotype_kmers_from_gfa(path gfa_path, size_t k, path paternal_kme
             prev_has_diploid = kmer.has_diploid;
         }    
     });
+    ks.normalize_kmer_counts();
     ks.print_component_parent_conf_matrix();
 }
 

--- a/src/executable/extract_haplotype_kmers_count_parent_kmers.cpp
+++ b/src/executable/extract_haplotype_kmers_count_parent_kmers.cpp
@@ -12,6 +12,7 @@
 
 #include <string>
 
+using namespace gfase;
 using gfase::HaplotypePathKmer;
 using gfase::IncrementalIdMap;
 using gfase::for_each_connected_component;
@@ -144,7 +145,8 @@ void extract_haplotype_kmers_from_gfa(path gfa_path, size_t k, path paternal_kme
                     kmer_string+=c;
                 }
                 // compare kmer to parental kmers
-                ks.find_haplotype_single_kmer_count(kmer_string);
+                pair <bool,bool> hap1_hap2 = ks.find_haplotype_single_kmer_count(kmer_string);
+                cerr << " hap1: " << hap1_hap2.first << " hap2: " << hap1_hap2.second;
                 cerr << '\n'; 
 
             }

--- a/src/executable/extract_haplotype_kmers_count_parent_kmers.cpp
+++ b/src/executable/extract_haplotype_kmers_count_parent_kmers.cpp
@@ -129,7 +129,7 @@ void extract_haplotype_kmers_from_gfa(path gfa_path, size_t k, path paternal_kme
 
     cerr << "Iterating path kmers..." << '\n';
 
-    cerr << " Number of (components?) in Graph: " << graph.get_path_count() << '\n';
+    cerr << " Number of components in graph: " << graph.get_path_count() << '\n';
 
     bool prev_has_diploid;
 

--- a/src/kmer_unordered_set.cpp
+++ b/src/kmer_unordered_set.cpp
@@ -38,7 +38,19 @@ KmerSets::KmerSets(path hap1_kmer_fa_path, path hap2_kmer_fa_path){
 	// fill the kmer sets 
     load_file_into_unordered_set(hap1_kmer_fa_path, hap1_kmer_set);
     load_file_into_unordered_set(hap2_kmer_fa_path, hap2_kmer_set);
+
+    cout << endl << "empty component_map: " << endl;
+    for (size_t i = 0; i < 2; i++) {
+
+		cout << "component: " << i << endl << "  |pat\t|mat" << endl;
+		
+		for (size_t j = 0; j < 2; j++) {
+			cout << j << " |" << component_map[i][j][parent_hap1_index] << "\t|" << component_map[i][j][parent_hap2_index] << "\t|" <<endl;
+		}
+		cout << endl;
+	}
 }
+
 
 float KmerSets::get_size_of_kmer_file(path file_path){
 	// # of kmers by (total file size/size of 2 lines)
@@ -98,21 +110,6 @@ void KmerSets::get_parent_kmer_sets(){
 
 }
 
-
-void KmerSets::print_component_parent_conf_matrix() {
-	cout << "Number of graph components: " << component_map.size() << endl;
-	
-	for (size_t i = 0; i < component_map.size(); i++) {
-
-		cout << "component: " << i << "\n  |pat\t|mat" << endl;
-		
-		for (size_t j = 0; j < 2; j++) {
-			cout << j << " |" << component_map[i][j][parent_hap1_index] << "\t|" << component_map[i][j][parent_hap2_index] << "\t|" <<endl;
-		}
-		cout << endl;
-	}
-}
-
 void KmerSets::parse_path_string(string path_string){
 	size_t string_delim = path_string.find('-');
 	this->graph_component = stoi(path_string.substr(0,string_delim));
@@ -136,6 +133,17 @@ bool KmerSets::increment_parental_kmer_count( string path_hap_string, string chi
 	return 0;
 }
 
+bool KmerSets::increment_parental_kmer_count(string path_name, unordered_set <string> child_kmers) {
+
+	unordered_set <string> :: iterator itr;
+	for (itr = child_kmers.begin(); itr != child_kmers.end(); itr++)
+		{
+			increment_parental_kmer_count(path_name,*itr);
+		}
+
+	return 0;
+}
+
 void KmerSets::normalize_kmer_counts(){
 	// divide by # of kmers for each parent
 
@@ -152,15 +160,18 @@ void KmerSets::normalize_kmer_counts(){
 	}
 }
 
-bool KmerSets::parental_kmer_count_for_kmer_set(string path_name, unordered_set <string> child_kmers) {
+void KmerSets::print_component_parent_conf_matrix() {
+	cout << "Number of graph components: " << component_map.size() << endl;
+	
+	for (size_t i = 0; i < component_map.size(); i++) {
 
-	unordered_set <string> :: iterator itr;
-	for (itr = child_kmers.begin(); itr != child_kmers.end(); itr++)
-		{
-			increment_parental_kmer_count(path_name,*itr);
+		cout << "component: " << i << "\n  |pat\t|mat" << endl;
+		
+		for (size_t j = 0; j < 2; j++) {
+			cout << j << " |" << component_map[i][j][parent_hap1_index] << "\t|" << component_map[i][j][parent_hap2_index] << "\t|" <<endl;
 		}
-
-	return 0;
+		cout << endl;
+	}
 }
 
 

--- a/src/kmer_unordered_set.cpp
+++ b/src/kmer_unordered_set.cpp
@@ -9,6 +9,8 @@
 using namespace std;
 using ghc::filesystem::path;
 
+namespace gfase {
+
 KmerSets::KmerSets(){};
 
 KmerSets::KmerSets(path hap1_kmer_fa_path, path hap2_kmer_fa_path){
@@ -74,22 +76,25 @@ void KmerSets::get_parent_kmer_sets(){
 }
 
 // single kmer find
-bool KmerSets::find_haplotype_single_kmer_count(string child_kmer) {
+//pair<bool,bool> that contains {hap0_found,hap1_found}
+pair<bool,bool> KmerSets::find_haplotype_single_kmer_count(string child_kmer) {
 	hap1_kmer_count = 0;
 	hap2_kmer_count = 0;
+	bool hap1_found = false;
+	bool hap2_found = false; 
 
 	if (hap1_kmer_set.find(child_kmer) != hap1_kmer_set.end()){
 		hap1_kmer_count++;
+		hap1_found = true;
 		}
 
 	if (hap2_kmer_set.find(child_kmer) != hap2_kmer_set.end()){
-		hap2_kmer_count++;		
+		hap2_kmer_count++;	
+		hap2_found=true;	
 		}
 
-	cout << " Checking single kmer: " << child_kmer << endl;
-	cout << " found " << hap1_kmer_count << " hap1 (hg03) kmers." << endl ;
-	cout << " found " << hap2_kmer_count << " hap2 (hg04) kmers." << endl << endl ;
-	return 0;
+	// consider that this limits to 2 haplotype assemblies
+	return pair(hap1_found,hap2_found);
 }
 
 // kmer set find
@@ -114,4 +119,4 @@ bool KmerSets::find_haplotype_kmer_set_count(unordered_set <string> child_kmers)
 	return 0;
 }
 
-
+}

--- a/src/kmer_unordered_set.cpp
+++ b/src/kmer_unordered_set.cpp
@@ -75,48 +75,52 @@ void KmerSets::get_parent_kmer_sets(){
 
 }
 
+void KmerSets::print_component_parent_conf_matrix() {
+	cout << "Number of graph components: " << component_map.size() << endl;
+	
+	for (int i = 0; i < component_map.size(); i++) {
+
+		cout << "component: " << i << "\n  _pat__mat_" << endl;
+		
+		for (int j = 0; j < 2; j++) {
+			cout << j << " | " << component_map[i][j][parent_hap1_int] << " | " << component_map[i][j][parent_hap2_int] << " |" <<endl;
+		}
+		cout << endl;
+	}
+}
+
+void KmerSets::parse_path_string(string path_string){
+	int string_delim = path_string.find('-');
+	this->graph_component = stoi(path_string.substr(0,string_delim));
+	this->component_haplotype = stoi(path_string.substr(string_delim+1,path_string.length()));
+}
+
 // single kmer find
-//pair<bool,bool> that contains {hap0_found,hap1_found}
-pair<bool,bool> KmerSets::find_haplotype_single_kmer_count(string child_kmer) {
-	hap1_kmer_count = 0;
-	hap2_kmer_count = 0;
-	bool hap1_found = false;
-	bool hap2_found = false; 
+bool KmerSets::increment_parental_kmer_count( string path_hap_string, string child_kmer) {
+
+	parse_path_string(path_hap_string);
 
 	if (hap1_kmer_set.find(child_kmer) != hap1_kmer_set.end()){
-		hap1_kmer_count++;
-		hap1_found = true;
+		component_map[graph_component][component_haplotype][parent_hap1_int]++;
 		}
 
 	if (hap2_kmer_set.find(child_kmer) != hap2_kmer_set.end()){
-		hap2_kmer_count++;	
-		hap2_found=true;	
+		component_map[graph_component][component_haplotype][parent_hap2_int]++;	
 		}
 
-	// consider that this limits to 2 haplotype assemblies
-	return pair(hap1_found,hap2_found);
-}
-
-// kmer set find
-bool KmerSets::find_haplotype_kmer_set_count(unordered_set <string> child_kmers) {
-	unordered_set <string> :: iterator itr;
-	hap1_kmer_count = 0;
-	hap2_kmer_count = 0;
-
-	for (itr = child_kmers.begin(); itr != child_kmers.end(); itr++)
-		{
-		if (hap1_kmer_set.find(*itr) != hap1_kmer_set.end()){
-			hap1_kmer_count++;
-			}
-
-		if (hap2_kmer_set.find(*itr) != hap2_kmer_set.end()){
-			hap2_kmer_count++;
-			}
-		}
-	cout << "checking kmer set." << endl;
-	cout << " found " << hap1_kmer_count << " hap1 (hg03) kmers." << endl;
-	cout << " found " << hap2_kmer_count << " hap2 (hg04) kmers." << endl << endl ;
 	return 0;
 }
+
+bool KmerSets::find_haplotype_kmer_set_count(string path_hap_string, unordered_set <string> child_kmers) {
+
+	unordered_set <string> :: iterator itr;
+	for (itr = child_kmers.begin(); itr != child_kmers.end(); itr++)
+		{
+			increment_parental_kmer_count(path_hap_string,*itr);
+		}
+
+	return 0;
+}
+
 
 }

--- a/src/kmer_unordered_set.cpp
+++ b/src/kmer_unordered_set.cpp
@@ -113,6 +113,14 @@ bool KmerSets::increment_parental_kmer_count( string path_hap_string, string chi
 	// this is done for each kmer - consider moving it out of this function
 	parse_path_string(path_hap_string);
 
+	// zero-innitialize the arrays' for each component
+	auto iter = component_map.find(graph_component);
+	if (iter == component_map.end()){
+		component_map.insert({graph_component, {{{0,0},{0,0}}}});
+		// cout << " first time innitializing: " << graph_component << " " << component_map[graph_component][component_haplotype][parent_hap1_index] << " " << component_map[graph_component][component_haplotype][parent_hap2_index]<< endl;
+		// 	}
+
+	// find child_kmer in each parent kmer_set
 	if (hap1_kmer_set.find(child_kmer) != hap1_kmer_set.end()){
 		component_map[graph_component][component_haplotype][parent_hap1_index]++;
 		}

--- a/src/kmer_unordered_set.cpp
+++ b/src/kmer_unordered_set.cpp
@@ -5,6 +5,7 @@
 #include <unordered_set>
 #include <fstream>
 #include "Filesystem.hpp"
+// #include <bits/stdc++.h>
 
 using namespace std;
 using ghc::filesystem::path;
@@ -30,14 +31,41 @@ KmerSets::KmerSets(path hap1_kmer_fa_path, path hap2_kmer_fa_path){
     }
 
     // fill the kmer sets 
-    load_file_into_unordered_set(hap1_kmer_fa_path, hap1_kmer_set);
-    load_file_into_unordered_set(hap2_kmer_fa_path, hap2_kmer_set);
+    load_file_into_unordered_set(hap1_kmer_fa_path, hap1_kmer_set, "hap1");
+    load_file_into_unordered_set(hap2_kmer_fa_path, hap2_kmer_set, "hap2");
 }
 
-void KmerSets::load_file_into_unordered_set(path file_path, unordered_set <string>& set){
+void KmerSets::get_size_of_kmer_file(path file_path, string hap){
+	// # of kmers by (total file size/size of 2 lines)
+
+	// size of 2 fa lines = size of 1 kmer
+	ifstream fileline(file_path, ios::binary );
+	streampos fsize = 0;
+	string fline;
+	// move 1 kmer = 2 lines through file and store size
+	getline(fileline, fline);
+	getline(fileline, fline);
+    fsize = fileline.tellg() - fsize;
+    // move to end
+    fileline.seekg(0,ios_base::end);
+	// set number of kmer variables
+	if (hap=="hap1"){
+		num_hap1_kmers=fileline.tellg()/fsize;
+		cout << hap << " kmer file path: " << file_path << "\n # kmers: " << num_hap1_kmers << endl;
+	}
+	if (hap=="hap2"){
+		num_hap2_kmers=fileline.tellg()/fsize;
+		cout << hap << " kmer file path: " << file_path << "\n # kmers: " << num_hap2_kmers << endl;
+	}
+
+}
+
+void KmerSets::load_file_into_unordered_set(path file_path, unordered_set <string>& set, string hap){
+	
+	get_size_of_kmer_file(file_path, hap);
+
 	// Read from the text file
 	ifstream KmerFile(file_path);
-	cout << "kmer path: " << file_path << endl << endl;
 
 	string line_txt;
 	// Use a while loop to read the file line by line
@@ -45,11 +73,9 @@ void KmerSets::load_file_into_unordered_set(path file_path, unordered_set <strin
 		// look for the > delimiting the kmer ID
 		size_t found = line_txt.rfind('>');
 		if (found!=string::npos){
-			// insert the kmer into the respective kmer set
-			// the line after the '>' in a fa
+			// insert kmer (line after the '>') into set
 			getline (KmerFile, line_txt);
 			set.insert(line_txt);
-			// cout << " kmer " << line_txt << endl << endl;
 		}
 	}
 	// Close the file
@@ -70,20 +96,21 @@ void KmerSets::get_parent_kmer_sets(){
     path relative_hap2_kmer_list_path = "data/hg04.all.homo.unique.kmer.1000.fa";
     path absolute_hap2_kmer_list_path = project_directory / relative_hap2_kmer_list_path;
 
-    load_file_into_unordered_set(absolute_hap1_kmer_list_path,hap1_kmer_set);
-    load_file_into_unordered_set(absolute_hap2_kmer_list_path,hap2_kmer_set);
+    load_file_into_unordered_set(absolute_hap1_kmer_list_path,hap1_kmer_set,"hap1");
+    load_file_into_unordered_set(absolute_hap2_kmer_list_path,hap2_kmer_set,"hap2");
 
 }
+
 
 void KmerSets::print_component_parent_conf_matrix() {
 	cout << "Number of graph components: " << component_map.size() << endl;
 	
 	for (int i = 0; i < component_map.size(); i++) {
 
-		cout << "component: " << i << "\n  _pat__mat_" << endl;
+		cout << "component: " << i << "\n   pat\tmat" << endl;
 		
 		for (int j = 0; j < 2; j++) {
-			cout << j << " | " << component_map[i][j][parent_hap1_int] << " | " << component_map[i][j][parent_hap2_int] << " |" <<endl;
+			cout << j << " |" << component_map[i][j][parent_hap1_int] << "\t|" << component_map[i][j][parent_hap2_int] << "\t|" <<endl;
 		}
 		cout << endl;
 	}
@@ -98,6 +125,7 @@ void KmerSets::parse_path_string(string path_string){
 // single kmer find
 bool KmerSets::increment_parental_kmer_count( string path_hap_string, string child_kmer) {
 
+	// this is done for each kmer - consider moving it out of this function
 	parse_path_string(path_hap_string);
 
 	if (hap1_kmer_set.find(child_kmer) != hap1_kmer_set.end()){
@@ -109,6 +137,22 @@ bool KmerSets::increment_parental_kmer_count( string path_hap_string, string chi
 		}
 
 	return 0;
+}
+
+void KmerSets::normalize_kmer_counts(){
+	// divide by # of kmers for each parent
+
+	cerr << "Normalize Component Map..\n";
+	for (int i = 0; i < component_map.size(); i++) {		
+		for (int j = 0; j < 2; j++) {
+			float raw_count = component_map[i][j][parent_hap1_int];
+			component_map[i][j][parent_hap1_int] = (raw_count/num_hap1_kmers);
+
+			raw_count = component_map[i][j][parent_hap2_int];
+			component_map[i][j][parent_hap2_int] = (raw_count/num_hap2_kmers);
+
+		}
+	}
 }
 
 bool KmerSets::find_haplotype_kmer_set_count(string path_hap_string, unordered_set <string> child_kmers) {

--- a/src/kmer_unordered_set.cpp
+++ b/src/kmer_unordered_set.cpp
@@ -5,7 +5,6 @@
 #include <unordered_set>
 #include <fstream>
 #include "Filesystem.hpp"
-// #include <bits/stdc++.h>
 
 using namespace std;
 using ghc::filesystem::path;
@@ -57,6 +56,7 @@ void KmerSets::get_size_of_kmer_file(path file_path, string hap){
 		num_hap2_kmers=fileline.tellg()/fsize;
 		cout << hap << " kmer file path: " << file_path << "\n # kmers: " << num_hap2_kmers << endl;
 	}
+	fileline.close();
 
 }
 

--- a/src/kmer_unordered_set.cpp
+++ b/src/kmer_unordered_set.cpp
@@ -117,8 +117,7 @@ bool KmerSets::increment_parental_kmer_count( string path_hap_string, string chi
 	auto iter = component_map.find(graph_component);
 	if (iter == component_map.end()){
 		component_map.insert({graph_component, {{{0,0},{0,0}}}});
-		// cout << " first time innitializing: " << graph_component << " " << component_map[graph_component][component_haplotype][parent_hap1_index] << " " << component_map[graph_component][component_haplotype][parent_hap2_index]<< endl;
-		// 	}
+			}
 
 	// find child_kmer in each parent kmer_set
 	if (hap1_kmer_set.find(child_kmer) != hap1_kmer_set.end()){

--- a/src/kmer_unordered_set.cpp
+++ b/src/kmer_unordered_set.cpp
@@ -39,17 +39,8 @@ KmerSets::KmerSets(path hap1_kmer_fa_path, path hap2_kmer_fa_path){
     load_file_into_unordered_set(hap1_kmer_fa_path, hap1_kmer_set);
     load_file_into_unordered_set(hap2_kmer_fa_path, hap2_kmer_set);
 
-    cout << endl << "empty component_map: " << endl;
-    for (size_t i = 0; i < 2; i++) {
-
-		cout << "component: " << i << endl << "  |pat\t|mat" << endl;
-		
-		for (size_t j = 0; j < 2; j++) {
-			cout << j << " |" << component_map[i][j][parent_hap1_index] << "\t|" << component_map[i][j][parent_hap2_index] << "\t|" <<endl;
-		}
-		cout << endl;
-	}
 }
+
 
 
 float KmerSets::get_size_of_kmer_file(path file_path){

--- a/src/test/test_kmer_unordered_set.cpp
+++ b/src/test/test_kmer_unordered_set.cpp
@@ -5,16 +5,33 @@
 using namespace gfase;
 
 int main() {
-	unordered_set <string> child_kmer_set;
-	child_kmer_set.insert("GATTATTTTTACATTAAGGTTATCACCTCAAATCCTTTTTTAAAAATAGTCAGCA");
-	child_kmer_set.insert("GGACTCTTCCCAGATGGATTTGAAACTTGAAATATGGAGGATAGAACTGTTACTG");
-	child_kmer_set.insert("GACTCTTCCCAGATGGATTTGAAACTTGAAATATGGAGGATAGAACTGTTACTGC");
-
+	
 	KmerSets KS;
 	KS.get_parent_kmer_sets();
-	// KS.fill_kmer_sets();  // with kmers that match the child set here
-	KS.find_haplotype_single_kmer_count("GACTCTTCCCAGATGGATTTGAAACTTGAAATATGGAGGATAGAACTGTTACTGC"); // dad kmer
-	KS.find_haplotype_single_kmer_count("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATCG"); // mom kmer
-	// KS.find_haplotype_kmer_set_count(child_kmer_set);
+	// change string into int 
+	int pathi = 0;
+	string path_string = "0-1"; // mom cout , dad count
+
+
+	// test single kmer counting
+	KS.increment_parental_kmer_count( path_string,"AAAAAAAAAAAAAAAAAAGGTGAAAGATCTGAACACCTCATTAATAAGATATACA"); // dad kmer
+	KS.increment_parental_kmer_count( path_string,"AAAAAAAAAAAAAAAAAAGGTGCATGAAACATATGAAGCAAAAAGTGAAAGTCCC");
+
+	path_string = "0-0";
+	KS.increment_parental_kmer_count( path_string,"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAATTAAAAAA");
+	
+	path_string = "0-1";
+	KS.increment_parental_kmer_count( path_string,"AAAAAAAAAAAAAAAAAAGGTGTCCATCCGAAAACCACCATTAAGAAACTCAGAC"); // dad kmer
+
+	// test kmer set counting
+	path_string = "1-1";
+	unordered_set <string> child_kmer_set;
+	child_kmer_set.insert("AAAAAAAAAAAAAAAAAAGGTGAAAGATCTGAACACCTCATTAATAAGATATACA"); //pat
+	child_kmer_set.insert("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACACCCAAAAAA"); // mat
+	child_kmer_set.insert("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACACAAAATAAA"); // mat
+	
+	KS.find_haplotype_kmer_set_count(path_string, child_kmer_set);
+
+	KS.print_component_parent_conf_matrix();
 
 }

--- a/src/test/test_kmer_unordered_set.cpp
+++ b/src/test/test_kmer_unordered_set.cpp
@@ -29,7 +29,7 @@ int main() {
 	child_kmer_set.insert("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACACCCAAAAAA"); // mat
 	child_kmer_set.insert("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACACAAAATAAA"); // mat
 	
-	KS.parental_kmer_count_for_kmer_set(path_string, child_kmer_set);
+	KS.increment_parental_kmer_count(path_string, child_kmer_set);
 
 	KS.print_component_parent_conf_matrix();
 

--- a/src/test/test_kmer_unordered_set.cpp
+++ b/src/test/test_kmer_unordered_set.cpp
@@ -2,6 +2,8 @@
 #include <unordered_set>
 #include <string>
 
+using namespace gfase;
+
 int main() {
 	unordered_set <string> child_kmer_set;
 	child_kmer_set.insert("GATTATTTTTACATTAAGGTTATCACCTCAAATCCTTTTTTAAAAATAGTCAGCA");

--- a/src/test/test_kmer_unordered_set.cpp
+++ b/src/test/test_kmer_unordered_set.cpp
@@ -10,12 +10,11 @@ int main() {
 	KS.get_parent_kmer_sets();
 	// change string into int 
 	int pathi = 0;
-	string path_string = "0-1"; // mom cout , dad count
-
+	string path_string = "0-1"; 
 
 	// test single kmer counting
 	KS.increment_parental_kmer_count( path_string,"AAAAAAAAAAAAAAAAAAGGTGAAAGATCTGAACACCTCATTAATAAGATATACA"); // dad kmer
-	KS.increment_parental_kmer_count( path_string,"AAAAAAAAAAAAAAAAAAGGTGCATGAAACATATGAAGCAAAAAGTGAAAGTCCC");
+	KS.increment_parental_kmer_count( path_string,"AAAAAAAAAAAAAAAAAAGGTGCATGAAACATATGAAGCAAAAAGTGAAAGTCCC"); // dad kmer
 
 	path_string = "0-0";
 	KS.increment_parental_kmer_count( path_string,"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAATTAAAAAA");

--- a/src/test/test_kmer_unordered_set.cpp
+++ b/src/test/test_kmer_unordered_set.cpp
@@ -8,8 +8,8 @@ int main() {
 	
 	KmerSets KS;
 	KS.get_parent_kmer_sets();
-	// change string into int 
-	int pathi = 0;
+	// change string into size_t 
+	size_t pathi = 0;
 	string path_string = "0-1"; 
 
 	// test single kmer counting
@@ -29,7 +29,7 @@ int main() {
 	child_kmer_set.insert("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACACCCAAAAAA"); // mat
 	child_kmer_set.insert("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACACAAAATAAA"); // mat
 	
-	KS.find_haplotype_kmer_set_count(path_string, child_kmer_set);
+	KS.parental_kmer_count_for_kmer_set(path_string, child_kmer_set);
 
 	KS.print_component_parent_conf_matrix();
 


### PR DESCRIPTION
I used the size of 2 lines of a kmer.fasta file to fine the number of kmers in the whole file. This can be used to reserve the size of the binary kmer array