### PR TITLE
Improved chaining in graphs with complex local structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ set(SOURCES
         src/BinarySequence.cpp
         src/binomial.cpp
         src/Bipartition.cpp
+        src/Bridges.cpp
         src/BubbleGraph.cpp
         src/chain.cpp
         src/Chainer.cpp
@@ -80,6 +81,7 @@ set(SOURCES
         src/PhaseAssign.cpp
         src/Sequence.cpp
         src/Sam.cpp
+        src/SubgraphOverlay.cpp
         src/SvgPlot.cpp
         src/Timer.cpp
 )
@@ -708,11 +710,12 @@ set(TESTS
         test_assign_phase
         test_binomial
         test_bfs
+        test_binary_sequence
+        test_binary_sequence_performance
+        test_bridges
         test_bubble_graph
         test_bubblegraph_chaining
         test_bubble_align
-        test_binary_sequence
-        test_binary_sequence_performance
         test_connected_component_finder
         test_contact_graph
         test_chainer

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -725,6 +725,7 @@ set(TESTS
         test_fixed_binary_sequence_performance_2
         test_fixed_binary_sequence_sparsepp_performance
         test_gfareader
+        test_hamiltonian_chainer
         test_hamiltonian_path
         test_htslib
         test_htslib_bam_reader

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ set(SOURCES
         src/gfa_to_handle.cpp
         src/graph_utility.cpp
         src/HamiltonianPath.cpp
+        src/HamiltonianChainer.cpp
         src/HaplotypePathKmer.cpp
         src/Hasher.cpp
         src/Hasher2.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ set(SOURCES
         src/GfaReader.cpp
         src/gfa_to_handle.cpp
         src/graph_utility.cpp
+        src/HamiltonianPath.cpp
         src/HaplotypePathKmer.cpp
         src/Hasher.cpp
         src/Hasher2.cpp
@@ -723,6 +724,7 @@ set(TESTS
         test_fixed_binary_sequence_performance_2
         test_fixed_binary_sequence_sparsepp_performance
         test_gfareader
+        test_hamiltonian_path
         test_htslib
         test_htslib_bam_reader
         test_incremental_id_io

--- a/inc/Bridges.hpp
+++ b/inc/Bridges.hpp
@@ -31,7 +31,7 @@ vector<vector<handle_t>> consolidate_bridges(const HandleGraph& graph,
 // execute a function on each bridge component, delimited by a (sub)set of consolidated
 // unipath bridges. the function is also given the set of bridges that delimit
 // the bridge component, which are identified by their index in the input vector
-// and the direction from the bridge into the component (true = left). if a bridge
+// and the direction from the bridge into the component (true = reverse). if a bridge
 // consists of multiple nodes, then only the innermost one is included in the subgraph.
 void for_each_bridge_component(const HandleGraph& graph,
                                const vector<vector<handle_t>>& bridges,

--- a/inc/Bridges.hpp
+++ b/inc/Bridges.hpp
@@ -1,20 +1,42 @@
 #ifndef GFASE_BRIDGES_HPP
 #define GFASE_BRIDGES_HPP
 
-#include "hash_graph.hpp"
+#include "bdsg/hash_graph.hpp"
 
 #include <vector>
+#include <functional>
 
 using bdsg::HandleGraph;
 using handlegraph::handle_t;
 
 using std::vector;
+using std::function;
+using std::pair;
 
 namespace gfase {
 
 // return the bridge nodes of the handle graph using Schmidt's (2013)
-// algorithm, assumes that graph is connected
+// algorithm. assumes that graph is connected. the returned bridges are
+// all in the forward orientation.
 vector<handle_t> bridge_nodes(const HandleGraph& graph);
+
+// consolidate runs of non-branching bridges into multi-node unipath bridges.
+// the returned unipaths will be ordered / oriented so that they represent a
+// valid walk of the bridge. the bridges argument can be a subset of all bridges.
+// assumes bridges are all provided in the forward orientation.
+vector<vector<handle_t>> consolidate_bridges(const HandleGraph& graph,
+                                             const vector<handle_t>& bridges);
+
+
+// execute a function on each bridge component, delimited by a (sub)set of consolidated
+// unipath bridges. the function is also given the set of bridges that delimit
+// the bridge component, which are identified by their index in the input vector
+// and the direction from the bridge into the component (true = left). if a bridge
+// consists of multiple nodes, then only the innermost one is included in the subgraph.
+void for_each_bridge_component(const HandleGraph& graph,
+                               const vector<vector<handle_t>>& bridges,
+                               const function<void(const HandleGraph&,
+                                                   const vector<pair<size_t, bool>>&)>& f);
 
 
 }

--- a/inc/Bridges.hpp
+++ b/inc/Bridges.hpp
@@ -1,0 +1,23 @@
+#ifndef GFASE_BRIDGES_HPP
+#define GFASE_BRIDGES_HPP
+
+#include "hash_graph.hpp"
+
+#include <vector>
+
+using bdsg::HandleGraph;
+using handlegraph::handle_t;
+
+using std::vector;
+
+namespace gfase {
+
+// return the bridge nodes of the handle graph using Schmidt's (2013)
+// algorithm, assumes that graph is connected
+vector<handle_t> bridge_nodes(const HandleGraph& graph);
+
+
+}
+
+
+#endif //GFASE_BRIDGES_HPP

--- a/inc/Chainer.hpp
+++ b/inc/Chainer.hpp
@@ -57,8 +57,26 @@ namespace gfase {
 
 using chain_t = deque <set <nid_t> >;
 
+/*
+ * The public-facing interface we will expect from all chainers
+ */
+class AbstractChainer {
+public:
+    virtual ~AbstractChainer() = default;
+    
+    // add phased haplotype paths to the graph
+    virtual void generate_chain_paths(MutablePathDeletableHandleGraph& graph,
+                                      const IncrementalIdMap<string>& id_map,
+                                      const MultiContactGraph& contact_graph) = 0;
+    
+    // is this the name of one of the phased haplotype paths?
+    virtual bool has_phase_chain(const string& name) const = 0;
+    // what is the partition of the phased hapotype path?
+    virtual int8_t get_partition(const string& name) const = 0;
+};
 
-class Chainer {
+
+class Chainer : public AbstractChainer {
     unordered_map<string,int8_t> path_phases;
     unordered_map<nid_t,nid_t> node_pairs;
     unordered_set<nid_t> diploid_nodes;

--- a/inc/Chainer.hpp
+++ b/inc/Chainer.hpp
@@ -73,6 +73,8 @@ public:
     virtual bool has_phase_chain(const string& name) const = 0;
     // what is the partition of the phased hapotype path?
     virtual int8_t get_partition(const string& name) const = 0;
+    // output any relevant information to bandage
+    virtual void write_chaining_results_to_bandage_csv(path output_dir, const IncrementalIdMap<string>& id_map) const = 0;
 };
 
 
@@ -133,7 +135,7 @@ public:
             const MultiContactGraph& contact_graph);
 
     // IO
-    void write_chainable_nodes_to_bandage_csv(path output_dir, const IncrementalIdMap<string>& id_map) const;
+    void write_chaining_results_to_bandage_csv(path output_dir, const IncrementalIdMap<string>& id_map) const;
 
     // Accessing
     bool has_phase_chain(const string& name) const;

--- a/inc/HamiltonianChainer.hpp
+++ b/inc/HamiltonianChainer.hpp
@@ -1,0 +1,62 @@
+#ifndef GFASE_HAMILTONIAN_CHAINER_HPP
+#define GFASE_HAMILTONIAN_CHAINER_HPP
+
+#include "MultiContactGraph.hpp"
+#include "IncrementalIdMap.hpp"
+#include "hash_graph.hpp"
+
+using bdsg::MutablePathDeletableHandleGraph;
+using bdsg::HandleGraph;
+using handlegraph::nid_t;
+
+#include <unordered_set>
+#include <utility>
+
+using std::unordered_set;
+using std::pair;
+using std::vector;
+
+namespace gfase {
+
+class HamiltonianChainer {
+public:
+    
+    HamiltonianChainer() = default;
+    ~HamiltonianChainer() = default;
+    
+    // expects nodes that do not have alts to have been deleted from
+    // the contact graph
+    void generate_chain_paths(MutablePathDeletableHandleGraph& graph,
+                              const IncrementalIdMap<string>& id_map,
+                              const MultiContactGraph& contact_graph) const;
+    
+    // the number of iterations we allow in a Hamiltonian path problem
+    size_t hamiltonian_max_iters = 5000;
+    
+private:
+    
+    // returns the confident left and right sides of the allelic walk through a component.
+    // if there is a full-length walk, only the first vector in the pair is filled.
+    // walks are all oriented away from the starts, toward the ends.
+    // also records whether the alleles were generated with a hamiltonian walk
+    pair<vector<handle_t>, vector<handle_t>> generate_allelic_semiwalks(const HandleGraph& graph,
+                                                                        const unordered_set<nid_t>& in_phase_nodes,
+                                                                        const unordered_set<nid_t>& out_phase_nodes,
+                                                                        const unordered_set<handle_t>& starts,
+                                                                        const unordered_set<handle_t>& ends
+                                                                        bool& resolved_hamiltonian) const;
+    
+    // the maximum length walk using only the allowed nodes before encountering
+    // a branch to multiple allowed nodes
+    vector<handle_t> max_unambiguous_path(const HandleGraph& graph, handle_t start,
+                                          const unordered_set<nid_t>& allowed_nodes) const;
+    
+    vector<handle_t> walk_diploid_unipath(const HandleGraph& graph, const MultiContactGraph& contact_graph
+                                          handle_t handle, bool go_left) const;
+    
+};
+
+}
+
+
+#endif //GFASE_HAMILTONIAN_CHAINER_HPP

--- a/inc/HamiltonianChainer.hpp
+++ b/inc/HamiltonianChainer.hpp
@@ -61,16 +61,21 @@ private:
     vector<handle_t> walk_diploid_unipath(const HandleGraph& graph, const MultiContactGraph& contact_graph,
                                           handle_t handle, bool go_left) const;
     
+    // check if we can extend phase path unambiguously into paths into components that
+    // we couldn't previously phase
+    void extend_unambiguous_phase_paths(MutablePathHandleGraph& graph,
+                                        const MultiContactGraph& contact_graph,
+                                        const array<unordered_set<path_handle_t>, 2>& phase_paths) const;
+    
     // split phase paths into 2 at self-loops
     void break_self_looping_phase_paths(MutablePathHandleGraph& graph,
                                         array<unordered_set<path_handle_t>, 2>& phase_paths,
                                         array<int, 2>& next_path_ids) const;
     
-    // check if we can extend phase path unambiguously into paths into components that
-    // we couldn't previously phase
-    void extend_unambiguous_phase_paths(MutablePathHandleGraph& graph,
-                                        array<unordered_set<path_handle_t>, 2>& phase_paths,
-                                        array<int, 2>& next_path_ids) const;
+    // remove phase paths that don't actually have any phased, haploid content
+    void purge_null_phase_paths(MutablePathHandleGraph& graph,
+                                const MultiContactGraph& contact_graph,
+                                array<unordered_set<path_handle_t>, 2>& phase_paths) const;
 };
 
 }

--- a/inc/HamiltonianChainer.hpp
+++ b/inc/HamiltonianChainer.hpp
@@ -27,7 +27,6 @@ public:
     // expects nodes that do not have alts to have been deleted from
     // the contact graph
     void generate_chain_paths(MutablePathDeletableHandleGraph& graph,
-                              const IncrementalIdMap<string>& id_map,
                               const MultiContactGraph& contact_graph) const;
     
     // the number of iterations we allow in a Hamiltonian path problem
@@ -43,7 +42,7 @@ private:
                                                                         const unordered_set<nid_t>& in_phase_nodes,
                                                                         const unordered_set<nid_t>& out_phase_nodes,
                                                                         const unordered_set<handle_t>& starts,
-                                                                        const unordered_set<handle_t>& ends
+                                                                        const unordered_set<handle_t>& ends,
                                                                         bool& resolved_hamiltonian) const;
     
     // the maximum length walk using only the allowed nodes before encountering
@@ -51,7 +50,7 @@ private:
     vector<handle_t> max_unambiguous_path(const HandleGraph& graph, handle_t start,
                                           const unordered_set<nid_t>& allowed_nodes) const;
     
-    vector<handle_t> walk_diploid_unipath(const HandleGraph& graph, const MultiContactGraph& contact_graph
+    vector<handle_t> walk_diploid_unipath(const HandleGraph& graph, const MultiContactGraph& contact_graph,
                                           handle_t handle, bool go_left) const;
     
 };

--- a/inc/HamiltonianChainer.hpp
+++ b/inc/HamiltonianChainer.hpp
@@ -40,6 +40,8 @@ public:
     bool has_phase_chain(const string& name) const;
     // what is the partition of the phased hapotype path?
     int8_t get_partition(const string& name) const;
+    // after generating chain paths, write them to bandage annotations
+    void write_chaining_results_to_bandage_csv(path output_dir, const IncrementalIdMap<string>& id_map) const;
     
     // the number of iterations we allow in a Hamiltonian path problem
     size_t hamiltonian_max_iters = 5000;

--- a/inc/HamiltonianChainer.hpp
+++ b/inc/HamiltonianChainer.hpp
@@ -5,16 +5,20 @@
 #include "IncrementalIdMap.hpp"
 #include "hash_graph.hpp"
 
-using bdsg::MutablePathDeletableHandleGraph;
+using bdsg::MutablePathHandleGraph;
 using bdsg::HandleGraph;
 using handlegraph::nid_t;
+using handlegraph::path_handle_t;
 
 #include <unordered_set>
 #include <utility>
+#include <array>
+#include <vector>
 
 using std::unordered_set;
 using std::pair;
 using std::vector;
+using std::array;
 
 namespace gfase {
 
@@ -26,7 +30,7 @@ public:
     
     // expects nodes that do not have alts to have been deleted from
     // the contact graph
-    void generate_chain_paths(MutablePathDeletableHandleGraph& graph,
+    void generate_chain_paths(MutablePathHandleGraph& graph,
                               const MultiContactGraph& contact_graph) const;
     
     // the number of iterations we allow in a Hamiltonian path problem
@@ -45,14 +49,28 @@ private:
                                                                         const unordered_set<handle_t>& ends,
                                                                         bool& resolved_hamiltonian) const;
     
+    // generate the path names we use to mark haplotypes
+    static string phase_path_name(int haplotype, int path_id);
+    
     // the maximum length walk using only the allowed nodes before encountering
     // a branch to multiple allowed nodes
     vector<handle_t> max_unambiguous_path(const HandleGraph& graph, handle_t start,
                                           const unordered_set<nid_t>& allowed_nodes) const;
     
+    // find the longest non-branching path that consists of only unphased (diploid) nodes starting at the handle
     vector<handle_t> walk_diploid_unipath(const HandleGraph& graph, const MultiContactGraph& contact_graph,
                                           handle_t handle, bool go_left) const;
     
+    // split phase paths into 2 at self-loops
+    void break_self_looping_phase_paths(MutablePathHandleGraph& graph,
+                                        array<unordered_set<path_handle_t>, 2>& phase_paths,
+                                        array<int, 2>& next_path_ids) const;
+    
+    // check if we can extend phase path unambiguously into paths into components that
+    // we couldn't previously phase
+    void extend_unambiguous_phase_paths(MutablePathHandleGraph& graph,
+                                        array<unordered_set<path_handle_t>, 2>& phase_paths,
+                                        array<int, 2>& next_path_ids) const;
 };
 
 }

--- a/inc/HamiltonianPath.hpp
+++ b/inc/HamiltonianPath.hpp
@@ -29,7 +29,7 @@ public:
     vector<handle_t> unique_prefix;
 };
 
-// empty vectors for starts or ends indicdate that any start or end node is allowed
+// empty sets for starts or ends indicdate that any start or end node is allowed
 // allowed starts and ends are oriented
 HamiltonianProblemResult find_hamiltonian_path(const HandleGraph& graph,
                                                const unordered_set<nid_t>& target_nodes,

--- a/inc/HamiltonianPath.hpp
+++ b/inc/HamiltonianPath.hpp
@@ -1,0 +1,41 @@
+#ifndef GFASE_HAMILTONIAN_PATH_HPP
+#define GFASE_HAMILTONIAN_PATH_HPP
+
+#include "bdsg/hash_graph.hpp"
+
+#include <vector>
+#include <unordered_set>
+#include <limits>
+
+using bdsg::HandleGraph;
+using handlegraph::handle_t;
+using handlegraph::nid_t;
+using std::vector;
+using std::unordered_set;
+using std::numeric_limits;
+
+namespace gfase {
+
+struct HamilonianProblemResult {
+public:
+    HamilonianProblemResult() = default;
+    ~HamilonianProblemResult() = default;
+    
+    bool is_solved = false;
+    vector<handle_t> hamiltonian_path;
+    bool is unique = false;
+    vector<handle_t> unique_prefix;
+}
+
+// empty vectors for starts or ends indicdate that any start or end node is allowed
+// allowed starts and ends are oriented
+HamilonianProblemResult find_hamiltonian_path(const HandleGraph& graph,
+                                              const unordered_set<nid_t>& target_nodes,
+                                              const unordered_set<nid_t>& prohibited_nodes,
+                                              const unordered_set<handle_t>& allowed_starts,
+                                              const unordered_set<handle_t>& allowed_ends,
+                                              size_t max_iters = numeric_limits<size_t>::max());
+
+}
+
+#endif // GFASE_HAMILTONIAN_PATH_HPP

--- a/inc/HamiltonianPath.hpp
+++ b/inc/HamiltonianPath.hpp
@@ -23,9 +23,9 @@ public:
     
     bool is_solved = false;
     vector<handle_t> hamiltonian_path;
-    bool is unique = false;
+    bool is_unique = false;
     vector<handle_t> unique_prefix;
-}
+};
 
 // empty vectors for starts or ends indicdate that any start or end node is allowed
 // allowed starts and ends are oriented

--- a/inc/HamiltonianPath.hpp
+++ b/inc/HamiltonianPath.hpp
@@ -16,14 +16,14 @@ using std::numeric_limits;
 
 namespace gfase {
 
-struct HamilonianProblemResult {
+struct HamiltonianProblemResult {
 public:
-    HamilonianProblemResult() = default;
-    ~HamilonianProblemResult() = default;
-    
+    HamiltonianProblemResult() = default;
+    ~HamiltonianProblemResult() = default;
     // true if the algorithm completed within the limit of iterations
     bool is_solved = false;
-    // a hamiltonian path identified (empty if the algorithm did not complete)
+    // a hamiltonian path identified (empty if the algorithm did not complete
+    // or there is no hamiltonian path)
     vector<handle_t> hamiltonian_path;
     // the prefix of the hamiltonian path that is shared among all possible solutions
     vector<handle_t> unique_prefix;
@@ -31,12 +31,12 @@ public:
 
 // empty vectors for starts or ends indicdate that any start or end node is allowed
 // allowed starts and ends are oriented
-HamilonianProblemResult find_hamiltonian_path(const HandleGraph& graph,
-                                              const unordered_set<nid_t>& target_nodes,
-                                              const unordered_set<nid_t>& prohibited_nodes,
-                                              const unordered_set<handle_t>& allowed_starts,
-                                              const unordered_set<handle_t>& allowed_ends,
-                                              size_t max_iters = numeric_limits<size_t>::max());
+HamiltonianProblemResult find_hamiltonian_path(const HandleGraph& graph,
+                                               const unordered_set<nid_t>& target_nodes,
+                                               const unordered_set<nid_t>& prohibited_nodes,
+                                               const unordered_set<handle_t>& allowed_starts,
+                                               const unordered_set<handle_t>& allowed_ends,
+                                               size_t max_iters = numeric_limits<size_t>::max());
 
 }
 

--- a/inc/HamiltonianPath.hpp
+++ b/inc/HamiltonianPath.hpp
@@ -21,9 +21,11 @@ public:
     HamilonianProblemResult() = default;
     ~HamilonianProblemResult() = default;
     
+    // true if the algorithm completed within the limit of iterations
     bool is_solved = false;
+    // a hamiltonian path identified (empty if the algorithm did not complete)
     vector<handle_t> hamiltonian_path;
-    bool is_unique = false;
+    // the prefix of the hamiltonian path that is shared among all possible solutions
     vector<handle_t> unique_prefix;
 };
 

--- a/inc/SubgraphOverlay.hpp
+++ b/inc/SubgraphOverlay.hpp
@@ -3,9 +3,14 @@
 
 #include "bdsg/hash_graph.hpp"
 
+#include <unordered_set>
+#include <string>
+
 using bdsg::HandleGraph;
+using bdsg::nid_t;
+using bdsg::handle_t;
 using std::string;
-using libhandlegraph::nid_t;
+using std::unordered_set;
 
 namespace gfase {
 
@@ -24,7 +29,7 @@ public:
      * while the overlay exists.
      *
      */
-    SubgraphOverlay(const HandleGraph& backing, const unordered_set<nid_t>& node_subset);
+    SubgraphOverlay(const HandleGraph* backing, const unordered_set<nid_t>* node_subset);
 
     ~SubgraphOverlay();
 

--- a/inc/SubgraphOverlay.hpp
+++ b/inc/SubgraphOverlay.hpp
@@ -1,0 +1,101 @@
+#ifndef GFASE_SUBGRAPH_OVERLAY_HPP_INCLUDED
+#define GFASE_SUBGRAPH_OVERLAY_HPP_INCLUDED
+
+#include "hash_graph.hpp"
+
+
+using bdsg::HandleGraph;
+using std::string;
+using libhandlegraph::nid_t;
+
+namespace gfase {
+
+
+/**
+ * Present a HandleGraph that is a backing HandleGraph but restricted
+ * to a subset of nodes.  It won't give handles to nodes not in the 
+ * subset, but it's not bulletproof: handles from outside the subset
+ * won't undergo any special checks.  
+ */
+class SubgraphOverlay : virtual public HandleGraph {
+
+public:
+    /**
+     * Make a new PathSubgraphOverlay. The backing graph must not be modified
+     * while the overlay exists.
+     *
+     */
+    SubgraphOverlay(const HandleGraph& backing, const unordered_set<nid_t>& node_subset);
+
+    ~SubgraphOverlay();
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Handle-based interface
+    ////////////////////////////////////////////////////////////////////////////
+
+    /// Method to check if a node exists by ID
+    bool has_node(nid_t node_id) const;
+   
+    /// Look up the handle for the node with the given ID in the given orientation
+    handle_t get_handle(const nid_t& node_id, bool is_reverse = false) const;
+    
+    /// Get the ID from a handle
+    nid_t get_id(const handle_t& handle) const;
+    
+    /// Get the orientation of a handle
+    bool get_is_reverse(const handle_t& handle) const;
+    
+    /// Invert the orientation of a handle (potentially without getting its ID)
+    handle_t flip(const handle_t& handle) const;
+    
+    /// Get the length of a node
+    size_t get_length(const handle_t& handle) const;
+    
+    /// Get the sequence of a node, presented in the handle's local forward
+    /// orientation.
+    string get_sequence(const handle_t& handle) const;
+    
+    /// Return the number of nodes in the graph
+    size_t get_node_count() const;
+    
+    /// Return the smallest ID in the graph, or some smaller number if the
+    /// smallest ID is unavailable. Return value is unspecified if the graph is empty.
+    nid_t min_node_id() const;
+    
+    /// Return the largest ID in the graph, or some larger number if the
+    /// largest ID is unavailable. Return value is unspecified if the graph is empty.
+    nid_t max_node_id() const;
+
+protected:
+    
+    /// Loop over all the handles to next/previous (right/left) nodes. Passes
+    /// them to a callback which returns false to stop iterating and true to
+    /// continue. Returns true if we finished and false if we stopped early.
+    bool follow_edges_impl(const handle_t& handle, bool go_left, const std::function<bool(const handle_t&)>& iteratee) const;
+    
+    /// Loop over all the nodes in the graph in their local forward
+    /// orientations, in their internal stored order. Stop if the iteratee
+    /// returns false. Can be told to run in parallel, in which case stopping
+    /// after a false return value is on a best-effort basis and iteration
+    /// order is not defined. Returns true if we finished and false if we 
+    /// stopped early.
+    bool for_each_handle_impl(const std::function<bool(const handle_t&)>& iteratee, bool parallel = false) const;
+
+protected:
+
+    /// the backing graph
+    const HandleGraph* backing_graph;
+
+    /// the node subset. note, we don't own this so its up to client to keep in scope,
+    /// just like the backing graph
+    const unordered_set<nid_t>* node_subset;
+    
+    /// keep min_node_id() and max_node_id() constant
+    nid_t min_node = 0;
+    nid_t max_node = 0;
+};
+
+
+}
+
+#endif // GFASE_SUBGRAPH_OVERLAY_HPP_INCLUDED

--- a/inc/SubgraphOverlay.hpp
+++ b/inc/SubgraphOverlay.hpp
@@ -1,8 +1,7 @@
 #ifndef GFASE_SUBGRAPH_OVERLAY_HPP_INCLUDED
 #define GFASE_SUBGRAPH_OVERLAY_HPP_INCLUDED
 
-#include "hash_graph.hpp"
-
+#include "bdsg/hash_graph.hpp"
 
 using bdsg::HandleGraph;
 using std::string;

--- a/inc/graph_utility.hpp
+++ b/inc/graph_utility.hpp
@@ -7,6 +7,7 @@
 #include "Filesystem.hpp"
 #include "GfaReader.hpp"
 #include "CLI11.hpp"
+#include "SubgraphOverlay.hpp"
 
 #include "bdsg/hash_graph.hpp"
 
@@ -76,6 +77,8 @@ void for_edge_in_bfs(
         const function<void(const handle_t& handle_a, const handle_t& handle_b)>& f);
 
 void for_each_connected_component(HandleGraph& graph, const function<void(unordered_set<nid_t>& connected_component)>& f);
+
+void for_each_connected_component_subgraph(HandleGraph& graph, const function<void(const HandleGraph& subgraph)>& f);
 
 void split_connected_components(
         MutablePathDeletableHandleGraph& graph,

--- a/src/Bridges.cpp
+++ b/src/Bridges.cpp
@@ -22,6 +22,7 @@ using std::cerr;
 using std::endl;
 
 using handlegraph::as_integer;
+using handlegraph::as_handle;
 using handlegraph::nid_t;
 
 namespace gfase {
@@ -62,8 +63,7 @@ size_t BiedgedGraph::size() const {
 }
 
 handle_t BiedgedGraph::get_arbitrary_node() const {
-    handle_t handle;
-    as_integer(handle) = -1; // to avoid uninitialized warnings
+    handle_t handle = as_handle(-1); // to avoid uninitialized warnings
     graph.for_each_handle([&handle](const handle_t& h) {
         handle = h;
         return false;

--- a/src/Bridges.cpp
+++ b/src/Bridges.cpp
@@ -1,0 +1,167 @@
+#include "Bridges.hpp"
+
+#include <functional>
+#include <unordered_map>
+#include <utility>
+
+using std::function;
+using std::pair;
+
+using handlegraph::as_integer;
+
+namespace gfase {
+
+/*
+ * Wrapper for a handle graph that uses the bi-edged formalism instead
+ * of a bidirected formalism, which allows a simple undirected graph
+ * interface
+ */
+class BiedgedGraph {
+public:
+    BiedgedGraph(const HandleGraph& graph);
+    BiedgedGraph() = delete;
+    
+    size_t size() const;
+    
+    // returns an invalid handle if graph is empty
+    handle_t get_arbitrary_node() const;
+    
+    void for_each_node(const function<void(handle_t)>& lambda) const;
+    // bool is true for across-node edges and false for adjacency edges
+    void for_each_neighbor(handle_t node, const function<void(handle_t, bool)>& lambda) const;
+    
+private:
+    
+    const HandleGraph& graph;
+    
+};
+
+BiedgedGraph::BiedgedGraph(const HandleGraph& graph) : graph(graph) {
+    
+}
+
+size_t BiedgedGraph::size() const {
+    return 2 * graph.size();
+}
+
+handle_t BiedgedGraph::get_arbitrary_node() const {
+    handle_t handle;
+    as_integer(handle) = -1; // to avoid uninitialized warnings
+    graph.for_each_handle([&handle](const handle_t& h) {
+        handle = h;
+        return false;
+    });
+    return handle;
+}
+
+
+void BiedgedGraph::for_each_node(const function<void(handle_t)>& lambda) const {
+    graph.for_each_handle([&graph](const handle_t& h) {
+        lambda(h);
+        lambda(graph.flip(h));
+    });
+}
+
+void BiedgedGraph::for_each_neighbor(handle_t node, const function<void(handle_t, bool)>& lambda) const {
+    
+    lambda(graph.flip(node), true);
+    graph.follow_edges(node, false, [&graph, &lambda](const handle_t& next) {
+        lambda(graph.flip(next), false);
+    });
+}
+
+vector<handle_t> bridge_nodes(const HandleGraph& graph) {
+    
+    BiedgedGraph undir_graph(graph);
+    
+    // TODO: should I just make this a class?
+    // records of node -> (edge upward, traversed upward, dfs index, edges downward)
+    unordered_map<handle_t, tuple<pair<handle_t, bool>, bool, size_t, vector<pair<handle_t, bool>>>> dfs_tree;
+    vector<handle_t> dfs_order;
+    
+    dfs_tree.reserve(undir_graph.size());
+    dfs_order.reserve(undir_graph.size());
+    
+    // records of (node, next edge idx, edges)
+    vector<tuple<handle_t, size_t, vector<pair<handle_t, bool>>>> stack;
+    
+    // enqueue a non-visited node
+    auto enqueue = [&](handle_t node, handle_t parent, bool from_across_edge) {
+        
+        stack.emplace_back(node, 0, vector<pair<handle_t, bool>>());
+        
+        // record the order and initialize the tree edges
+        dfs_tree[node].emplace_back({parent, from_across_edge}, false, dfs_order.sizse(), {});
+        dfs_order.emplace_back(node);
+        
+        undir_graph.for_each_neighbor(node, [&](handle_t nbr, bool is_across_edge) {
+            get<2>(stack.back()).emplace_back(nbr, is_across_edge);;
+        });
+    };
+    
+    // DFS
+    handle_t root = undir_graph.get_arbitrary_node();
+    enqueue(root, root, false);
+    // note: the root doesn't really have a parent, but we use itself as a sentinel
+    while (!stack.empty()) {
+        
+        auto& top = stack.back();
+        
+        if (get<1>(top) == get<2>(top).size()) {
+            // exhausted edges from this node
+            stack.pop_back();
+            continue;
+        }
+        
+        auto next = get<2>(top)[get<1>(top)++];
+        
+        if (!dfs_tree.count(next.first)) {
+            // the next node hasn't been visited yet, so we add its edge to
+            // the DFS tree and queue it up
+            get<3>(dfs_tree[get<0>(top)]).emplace_back(next);
+            enqueue(next.first, get<0>(top), next.second);
+        }
+    }
+    
+    for (size_t i = 0; i < dfs_order.size(); ++i) {
+        
+        handle_t node = dfs_order[i];
+        
+        // get the non-tree edges that will initiate chains
+        vector<handle_t> chain_heads;
+        // note: we count on the edges being iterated in the same order as previously
+        const auto& tree_record = dfs_order[node];
+        size_t j = 0;
+        undir_graph.for_each_neighbor(node, [&](handle_t nbr, bool is_across_edge) {
+            if (j < get<3>(tree_record).size() && get<3>(tree_record)[j] == make_pair(nbr, is_across_edge)) {
+                // this edge was used in the DFS tree
+                ++j;
+            }
+            else if (get<2>(tree_record) > i) {
+                // this edge points down the tree rather than up it
+                chain_heads.emplace_back(nbr);
+            }
+        });
+        
+        // mark nodes in the untraversed portion of this chain's cycle as traversed
+        for (handle_t chain_cursor : chain_heads) {
+            while (chain_cursor != node && !get<1>(dfs_tree[chain_cursor])) {
+                get<1>(dfs_tree[chain_cursor]) = true;
+                chain_cursor = get<0>(dfs_tree[chain_cursor]).first;
+            }
+        }
+    }
+    
+    // find the across-node edges that were never traversed in a cycle
+    vector<handle_t> bridges;
+    
+    for (const auto& tree_record : dfs_tree) {
+        if (!get<1>(tree_record.second) && get<0>(tree_record.second).second) {
+            bridges.push_back(graph.forward(tree_record.first));
+        }
+    }
+    
+    return bridges;
+}
+
+}

--- a/src/Chainer.cpp
+++ b/src/Chainer.cpp
@@ -571,7 +571,8 @@ int8_t Chainer::get_partition(const string& name) const{
 }
 
 
-void Chainer::write_chainable_nodes_to_bandage_csv(path output_dir, const IncrementalIdMap<string>& id_map) const{
+void Chainer::write_chaining_results_to_bandage_csv(path output_dir,
+                                                    const IncrementalIdMap<string>& id_map) const{
     path output_path = output_dir / "chainable_nodes.csv";
     ofstream file(output_path);
 

--- a/src/HamiltonianChainer.cpp
+++ b/src/HamiltonianChainer.cpp
@@ -110,7 +110,7 @@ void HamiltonianChainer::generate_chain_paths(MutablePathDeletableHandleGraph& g
     
     /*
      * Part 2: identify walks through bridge components with bridge degree <= 2 and
-     * non-bridge simple bubbles
+     * non-bridge-bordered simple bubbles
      */
     
     // we'll try to fill these out for each bridge component

--- a/src/HamiltonianChainer.cpp
+++ b/src/HamiltonianChainer.cpp
@@ -1,0 +1,691 @@
+#include "HamiltonianChainer.hpp"
+
+#include "handlegraph/util.hpp"
+#include "handlegraph/types.hpp"
+
+using handlegraph::as_handle;
+using handlegraph::handle_t;
+using handlegraph::path_handle_t;
+
+#include <vector>
+#include <unordered_set>
+#include <unordered_map>
+#include <set>
+#include <cassert>
+#include <deque>
+#include <array>
+#include <algorithm>
+
+using std::vector;
+using std::unordered_set;
+using std::unordered_map;
+using std::set;
+using std::move;
+using std::deque;
+using std::array;
+using std::reverse;
+
+namespace gfase {
+
+/*
+ * A 0-, 1-, or 2-sided component with 2 fully or partially walked alleles
+ */
+struct ChainableComponent {
+    ChainableComponent() = default;
+    ~ChainableComponent() = default;
+    
+    // we assume that the left side is assigned first (i.e. there can be a left
+    // side and no right side, but not the reverse)
+    // the sides point are oriented to point into the component
+    bool has_left_side = false;
+    bool has_right_side = false;
+    handle_t left_side = as_handle(-1);
+    handle_t right_side = as_handle(-1);
+    
+    // the longest certain alleles we can walk inward from the left boundaries.
+    // if there are no boundaries, these start from an arbitrary node.
+    // includes the boundary node(s) when they are present
+    array<vector<handle_t>, 2> allele_from_left;
+    
+    // the longest certain alleles we can walk inward from the right boundaries.
+    // left blank if there is no right boundary, or if the left-side allele spans
+    // the entire component
+    array<vector<handle_t>, 2> allele_from_right;
+    
+};
+
+
+HamiltonianChainer::generate_chain_paths(MutablePathDeletableHandleGraph& graph,
+                                         const IncrementalIdMap<string>& id_map,
+                                         const MultiContactGraph& contact_graph) {
+    
+    
+    /*
+     * Part 1: find bridges
+     */
+    
+    // find bridges that are not assigned to one or the other haplotype
+    vector<handle_t> nonhaploid_bridges;
+    for_each_connected_component_subgraph(graph, [&](const HandleGraph& component) {
+        for (handle_t bridge : bridge_nodes(component)) {
+            if (!contact_graph.has_node(graph.get_id(bridge)) ||
+                !contact_graph.has_alt(graph.get_id(bridge))) {
+                nonhaploid_bridges.push_back(bridge);
+            }
+        }
+    });
+    
+    // merge into unipath bridges
+    auto unipath_bridges = consolidate_bridges(graph, nonhaploid_bridges);
+    
+    // and we can use this to look up bridges by their component-facing boundaries
+    unordered_map<handle_t, size_t> boundary_to_bridge;
+    boundary_to_bridge.reserve(2 * unipath_bridges.size());
+    for (size_t i = 0; i < unipath_bridges.size(); ++i) {
+        const auto& unipath_bridge = unipath_bridges[i];
+        boundary_to_bridge[graph.flip(unipath_bridge.front())] = i;
+        boundary_to_bridge[unipath_bridge.back()] = i;
+    }
+    
+    /*
+     * Part 2: identify walks through bridge components with bridge degree <= 2 and
+     * non-bridge simple bubbles
+     */
+    
+    // we'll try to fill these out for each bridge component
+    unordered_map<handle_t, size_t> boundary_to_chain_link;
+    vector<ChainableComponent> chain_links;
+    
+    vector<vector<handle_t>> bubble_unipath_boundaries;
+    
+    for_each_bridge_component(graph, unipath_bridges,
+                              [&](const HandleGraph& bridge_component,
+                                  const vector<pair<size_t, bool>>& incident_bridges) {
+        
+        
+        bool found_allele_success = false;
+        if (incident_bridges.size() <= 2) {
+            
+            // this bridge component is a potentially phaseable unit in itself
+            
+            // check that the bridge component looks like it's capturing two allelic sequences
+            unordered_set<nid_t> phase_0_nodes, phase_1_nodes;
+            bool all_phasable = bridge_component.for_each_handle([&](const handle_t& handle) {
+                
+                nid_t node_id = bridge_component.get_id(handle);
+                if (phase_0_nodes.count(node_id) || phase_1_nodes.count(node_id)) {
+                    // we already processed this node from another node's alt component
+                    return true;
+                }
+                if (contact_graph.has_node(node_id) && contact_graph.has_alt(node_id)) {
+                    alt_component_t alt_component;
+                    contact_graph.get_alt_component(node_id, false, alt_component);
+                    for (auto alt_set : {&alt_component.first, &alt_component.second}) {
+                        for (auto member_id : *alt_set) {
+                            if (!bridge_component.has_node(member_id)) {
+                                // a member of this alt set is not found in the bridge component.
+                                // this makes it less likely that the bridge component represents
+                                // a pair of allelic sequences, but we'll still allow it as long as
+                                // the missing sequences are isolated nodes
+                                // TODO: this condition is motivated by patterns we've seen in
+                                // verkko graphs, but it could stand to be a bit more principled
+                                handle_t missing_node = graph.get_handle(member_id);
+                                bool no_edges = graph.follow_edges(missing_node, false, [&](const handle_t& null) {
+                                    return false;
+                                });
+                                no_edges = no_edges && graph.follow_edges(missing_node, true, [&](const handle_t& null) {
+                                    return false;
+                                });
+                                if (!no_edge) {
+                                    // this bridge component is not phasable
+                                    return false;
+                                }
+                            }
+                        }
+                    }
+                    // record the phase of the two alt sets (which also marks them as having been processed)
+                    bool order_swapped = (contact_graph.get_partition(*alt_component.first.begin()) > 0);
+                    for (auto alt_allele_id : (order_swapped ? alt_component.second : alt_component.first)) {
+                        if (bridge_component.has_node(alt_allele_id)) {
+                            phase_0_nodes.insert(alt_allele_id);
+                        }
+                    }
+                    for (auto alt_allele_id : (order_swapped ? alt_component.first : alt_component.second)) {
+                        if (bridge_component.has_node(alt_allele_id)) {
+                            phase_1_nodes.insert(alt_allele_id);
+                        }
+                    }
+                }
+            });
+            
+            if (!all_phasable) {
+                // the nodes had alts that are outside this bridge component
+                return;
+            }
+            
+            unordered_set<handle_t> start, end;
+            if (incident_bridges.size() >= 1) {
+                // we'll start at the inward side of the bridge, facing into to the component
+                const auto& start_bridge = unipath_bridges[incident_bridges[0].first];
+                if (incident_bridges[0].second) {
+                    start.insert(graph.flip(start_bridge.front()));
+                }
+                else {
+                    start.insert(start_bridge.back());
+                }
+            }
+            if (incident_bridges.size() == 2) {
+                // we'll end at the inward side of the bridge, but facing outward
+                const auto& end_bridge = unipath_bridges[incident_bridges[1].first];
+                if (incident_bridges[1].second) {
+                    end.insert(end_bridge.front());
+                }
+                else {
+                    end.insert(graph.flip(end_bridge.back()));
+                }
+            }
+            
+            bool resolved_hamiltonian_0;
+            auto phase_0_walks = generate_allelic_semiwalks(bridge_component,
+                                                            phase_0_nodes,
+                                                            phase_1_nodes,
+                                                            start, end,
+                                                            resolved_hamiltonian_0);
+            
+            bool resolved_hamiltonian_1;
+            auto phase_1_walks = generate_allelic_semiwalks(bridge_component,
+                                                            phase_1_nodes,
+                                                            phase_0_nodes,
+                                                            start, end,
+                                                            resolved_hamiltonian_1);
+            
+            // we'll consider this bridge component fully solved (even without unique alleles)
+            // if we found a hamiltonian path for either of the phases
+            found_allele_success = (resolved_hamiltonian_0 || resolved_hamiltonian_1);
+            
+            // record the result of the allele identification
+            chain_links.emplace_back();
+            auto& link = chain_links.back();
+            if (!starts.empty()) {
+                link.has_left_side = true;
+                link.left_side = *start.begin();
+                boundary_to_chain_link[link.left_side] = chain_links.size() - 1;
+            }
+            if (!end.empty()) {
+                link.has_right_side = true;
+                link.right_side = bridge_component.flip(*end.begin());
+                boundary_to_chain_link[link.right_side] = chain_links.size() - 1;
+            }
+            link.allele_from_left[0] = move(phase_0_walks.first);
+            link.allele_from_right[0] = move(phase_0_walks.second);
+            link.allele_from_left[1] = move(phase_1_walks.first);
+            link.allele_from_right[1] = move(phase_1_walks.second);
+        }
+        
+        if (incident_bridges.size() > 2 || !found_allele_success) {
+            // this bridge component has bridge degree > 2 or else the hamiltonian algorithm failed on both
+            // alleles. we could maybe find phaseable ubbles inside it using a rigid topological motif criterion
+            
+            unordered_set<handle_t> processed_sides;
+            bridge_component.for_each_handle([&](const handle_t& handle) {
+                nid_t node_id = bridge_component.get_id(handle);
+                if (contact_graph.has_node(node_id) && contact_graph.has_alt(node_id)) {
+                    // we don't want to find haploid allelic sequences, we want boundaries of bubbles
+                    return;
+                }
+                for (auto side : {handle, bridge_component.flip(handle)}) {
+                    if (processed_sides.count(side)) {
+                        continue;
+                    }
+                    // check if this is the boundary of a bubble
+                    processed_sides.insert(side);
+                    
+                    vector<handle_t> neighbors;
+                    bridge_component.follow_edges(side, false, [&](const handle_t& nbr) {
+                        neighbors.push_back(nbr);
+                    });
+                    if (neighbors.size() != 2) {
+                        // these can't be the two sides of a bubble
+                        continue;
+                    }
+                    array<int, 2> neighbor_rev_count{0, 0};
+                    for (int hap : {0, 1}) {
+                        bridge_component.follow_edges(neighbors[hap], true, [&](const handle_t& prev) {
+                            ++neighbor_rev_count[hap];
+                            return neighbor_rev_count[hap] < 2;
+                        });
+                    }
+                    if (neighbor_rev_count[0] != 1 || neighbor_rev_count[1] != 1) {
+                        // you can reach the two nodes from other nodes than the boundary
+                        continue;
+                    }
+                    array<handle_t, 2> next_neighbor{as_handle(-1), as_handle(-1)};
+                    bool deg_less_than_2 = true;
+                    for (int hap : {0, 1}) {
+                        deg_less_than_2 = deg_less_than_2 && bridge_component.follow_edges(neighbors[hap], false,
+                                                                                           [&](const handle_t& next) {
+                            if (next_neighbor[hap] != as_handle(-1)) {
+                                return false;
+                            }
+                            else {
+                                next_neighbor[hap] = next;
+                                return true;
+                            }
+                        });
+                    }
+                    if (next_neighbor[0] == as_handle(-1) || next_neighbor[0] != next_neighbor[1] || !deg_less_than_2) {
+                        // they don't meet together at the following node
+                        continue;
+                    }
+                    size_t next_neighbor_rev_count = 0;
+                    bridge_component.follow_edges(next_neighbor[0], true, [&](const handle_t& prev) {
+                        ++next_neighbor_rev_count;
+                        return next_neighbor_rev_count < 3;
+                    });
+                    if (next_neighbor_rev_count > 2) {
+                        // other nodes also meet together at the following node
+                        continue;
+                    }
+                    
+                    if (!contact_graph.has_node(bridge_component.get_id(neighbors[0])) ||
+                        !contact_graph.has_node(bridge_component.get_id(neighbors[1]))) {
+                        // these can't have an assigned phase
+                        continue;
+                    }
+                    alt_component_t alt_component;
+                    contact_graph.get_alt_component(bridge_component.get_id(neighbors[0]), false, alt_component);
+                    if (alt_component.first.size() != 1 || alt_component.second size != 1) {
+                        // these have other homology partners outside of this motif
+                        continue;
+                    }
+                    if ((*alt_component.first.begin() != bridge_component.get_id(neighbors[0]) ||
+                         *alt_component.second.begin() != bridge_component.get_id(neighbors[1])) &&
+                        (*alt_component.second.begin() != bridge_component.get_id(neighbors[0]) ||
+                         *alt_component.first.begin() != bridge_component.get_id(neighbors[1]))) {
+                        // they aren't homology partners with each other
+                        continue;
+                    }
+                    if (contact_graph.has_node(bridge_component.get_id(next_neighbor[0])) &&
+                        contact_graph.has_alt(bridge_component.get_id(next_neighbor[0]))) {
+                        // the other boundary is phased (i.e. isn't diploid)
+                        continue;
+                    }
+                    
+                    // we've fully checked the local topology, this looks like a phased bubble
+                    
+                    chain_links.emplace_back();
+                    auto& link = chain_links.back();
+                    link.has_left_side = true;
+                    link.left_side = side;
+                    link.has_right_side = true;
+                    link.right_side = bridge_component.flip(next_neighbor[0]);
+                    
+                    // form the alleles
+                    vector<handle_t> allele_0{side, neighbors[0], next_neighbor[0]};
+                    vector<handle_t> allele_1{side, neighbors[1], next_neighbor[0]};
+                    bool order_swapped = (contact_graph.get_partition(bridge_component.get_id(neighbors[0])) > 0);
+                    link.allele_from_left[0] = (order_swapped ? move(allele_1) : move(allele_0));
+                    link.allele_from_left[1] = (order_swapped ? move(allele_0) : move(allele_1));
+                    
+                    bubble_unipath_boundaries.push_back(walk_diploid_unipath(link.left_side, true));
+                    bubble_unipath_boundaries.push_back(walk_diploid_unipath(link.right_side, false));
+                    
+                    processed_sides.insert(side);
+                    for (int i = 0; i < 2; ++i) {
+                        processed_sides.insert(neighbors[i]);
+                        processed_sides.insert(bridge_component.flip(neighbors[i]));
+                    }
+                    processed_sides.insert(bridge_component.flip(next_neighbor[0]));
+                }
+            });
+        }
+    });
+    
+    // move the unipath boundaries from the bubbles to the same list as the bridges (even though
+    // they're technically not bridges)
+    // note: we don't need to worry about re-identifuying a bridge because if a bridge satisfied
+    // the rigid topological bubble criterion, then it would have been solved by the hamiltonian
+    for (auto& unipath_bridge = unipath_bridges[i]) {
+        boundary_to_bridge[graph.flip(unipath_bridge.front())] = unipath_bridges.size();
+        boundary_to_bridge[unipath_bridge.back()] = unipath_bridges.size();
+        unipath_bridges.emplace_back(move(unipath_bridge));
+    }
+    
+    /*
+     * Part 3: find bridges
+     */
+    
+    array<int, 2> next_path_id{0, 0};
+    auto get_next_path_name = [&](int hap) {
+        return string("gfase_hap_" + to_string(next_path_id[hap]++) +"_" + to_string(hap));
+    };
+    
+    vector<bool> is_chained(chain_links.size(), false);
+    
+    // add the next bridge and chain link to the growing chain
+    // TODO: if i split this into the bridge and the component walk, i could avoid doing the same
+    // bridge traversing logic on both haplotypes...
+    auto add_next_component = [&](int haplotype,
+                                  bool extending_backward,
+                                  bool& left_to_right, // which direction is "forward" relative to the path
+                                  path_handle_t& curr_path,
+                                  int64_t& curr_link_idx,
+                                  bool& keep_going,
+                                  bool& found_cycle) {
+        
+        auto& curr_link = chain_links[curr_link_idx];
+        bool go_to_left = (extending_backward == left_to_right);
+        if ((!curr_link.has_left_side && go_to_left) || (!curr_link.has_right_side && !go_to_left)) {
+            // TODO: should i actually mark that we don't keep going after adding the allele?
+            keep_going = false;
+            return;
+        }
+        
+        // add the nodes of the bridge
+        handle_t adjacent_side = go_to_left ? curr_link.left_side : curr_link.right_side;
+        size_t bridge_idx = boundary_to_bridge.at(adjacent_side);
+        auto& unipath_bridge = unipath_bridges[bridge_idx];
+        handle_t final_outward;
+        if (unipath_bridge.back() == adjacent_side) {
+            // we're traversing the bridge backwards
+            for (int64_t j = unipath_bridges.size() - 2; j >= 0; --j) {
+                if (extending_backward) {
+                    graph.prepend_step(curr_path, unipath_bridge[j]);
+                }
+                else {
+                    graph.append_step(curr_path, graph.flip(unipath_bridge[j]));
+                }
+            }
+            final_outward = graph.flip(unipath_bridges.front());
+        }
+        else {
+            // we're traversing the bridge forwards
+            assert(adjacent_side == graph.flip(unipath_bridge.front()));
+            for (size_t j = 1; j < unipath_bridges.size(); ++j) {
+                if (extending_backward) {
+                    graph.prepend_step(curr_path, graph.flip(unipath_bridge[j]));
+                }
+                else {
+                    graph.append_step(curr_path, unipath_bridge[j]);
+                }
+            }
+            final_outward = graph.flip(unipath_bridges.front());
+        }
+        
+        // gather information about the next chain link and its orientation
+        curr_link_idx = boundary_to_chain_link.at(final_outward);
+        if (is_chained[curr_link_idx]) {
+            // we've previously walked this chain (probably it's in a cycle) and don't want
+            // to do it again
+            // FIXME: should we make the path be cyclic then?
+            keep_going = false;
+            found_cycle = true;
+            return;
+        }
+        auto& next_link = chain_links[curr_link_idx];
+        assert(final_outward == next_link.left_side || final_outward == next_link.right_side);
+        bool enter_left = final_outward == next_link.left_side;
+        left_to_right = enter_left != extending_backward;
+        
+        // handles the logic of adding either the left or right allele onto the path, optionally
+        // checks consistency of whether
+        auto add_allele = [&](const vector<handle_t>& allele, handle_t* check_inward) {
+            if (enter_left) {
+                // we traverse this component left to right
+                if (check_inward) {
+                    assert(*check_inward == (left_to_right ? allele.front() : graph.flip(allele.front())));
+                }
+                for (size_t i = 1; i < allele.size(); ++i) {
+                    if (extending_backward) {
+                        graph.prepend_step(curr_path, graph.flip(allele[i]));
+                    }
+                    else {
+                        graph.append_step(curr_path, allele[i]);
+                    }
+                }
+            }
+            else {
+                // we traverse this component right to left
+                if (check_inward) {
+                    assert(*check_inward == (left_to_right ? allele.back() : graph.flip(allele.back())));
+                }
+                for (int64_t i = allele.size() - 2; i >= 0; --i) {
+                    if (extending_backward) {
+                        graph.prepend_step(curr_path, allele[i]);
+                    }
+                    else {
+                        graph.append_step(curr_path, graph.flip(allele[i]));
+                    }
+                }
+            }
+        };
+        
+        // add the alleles to the path
+        if (next_link.allele_from_right[haplotype].empty()) {
+            // the left walk goes across the entire link, or else there is no right side
+            add_allele(next_link.allele_from_left[haplotype], &final_outward);
+            keep_going = next_link.has_right_side;
+        }
+        else {
+            // the walk is broken in the middle
+            auto& left_allele = next_link.allele_from_left[haplotype];
+            auto& right_allele = next_link.allele_from_right[haplotype];
+            if (enter_left) {
+                add_allele(left_allele, &final_outward);
+                // end the haplotype path and start a new one
+                curr_path = graph.create_path_handle(get_next_path_name(haplotype));
+                add_allele(right_allele, nullptr);
+            }
+            else {
+                add_allele(right_allele, &final_outward);
+                // end the haplotype path and start a new one
+                curr_path = graph.create_path_handle(get_next_path_name(haplotype));
+                add_allele(left_allele, nullptr);
+            }
+        }
+        
+        is_chained[curr_link_idx] = true;
+    };
+    
+    for (size_t i = 0; i < chain_links.size(); ++i) {
+        if (is_chained[i]) {
+            continue;
+        }
+        
+        // make paths to extend into haplotypes
+        array<path_handle_t, 2> init_paths;
+        for (int hap : {0, 1}) {
+            init_paths[hap] = graph.create_path_handle(get_next_path_name(hap));
+        }
+        array<path_handle_t, 2> curr_paths = init_paths;
+        auto& init_link = chain_links[i];
+        for (int hap : {0, 1}) {
+            for (handle_t step : init_link.allele_from_left[hap]) {
+                graph.append_step(curr_paths[hap], step);
+            }
+        }
+        // TODO: it's a bit silly that i maintain these variables separately for both haplotypes,
+        // but i don't want it to get set during one haplotype iteration and mess up the next
+        array<bool, 2> link_is_left_to_right{true, true};
+        array<int64_t, 2> link_index{i, i};
+        bool keep_going = init_link.has_left_side;
+        bool found_cycle = false;
+        
+        // start by extending to the left
+        while (keep_going) {
+            for (int hap : {0, 1}) {
+                add_next_component(hap, true, link_is_left_to_right[hap],
+                                   curr_path[hap], link_index[hap], keep_going, found_cycle);
+            }
+        }
+        
+        if (found_cycle) {
+            // we looped back around to the same link, but we might not have included the
+            // right side of this link
+            for (int hap : {0, 1}) {
+                auto& allele = init_link.allele_from_right[hap];
+                if (!allele.empty()) {
+                    for (int64_t j = allele.size() - 2; j >= 0; --j) {
+                        graph.prepend_step(curr_paths[hap], allele[j]);
+                    }
+                }
+            }
+        }
+        else if (init_link.has_right_side) {
+            // now we extend to the right
+            
+            // initialize the rightward traversal
+            keep_going = true;
+            for (int hap : {0, 1}) {
+                link_is_left_to_right[hap] = true;
+                link_index[hap] = i;
+                if (init_link.allele_from_right[hap].empty()) {
+                    // we can continue the initial allele
+                    curr_paths[hap] = init_paths[hap]
+                }
+                else {
+                    // we have to start a new path
+                    curr_paths[hap] = graph.create_path_handle(get_next_path_name(hap));
+                }
+                for (handle_t step : init_link.allele_from_right[hap]) {
+                    graph.append_step(curr_paths[hap], step);
+                }
+            }
+            
+            // add links to the right
+            while (keep_going) {
+                for (int hap : {0, 1}) {
+                    add_next_component(hap, false, link_is_left_to_right[hap],
+                                       curr_path[hap], link_index[hap], keep_going, found_cycle);
+                }
+            }
+        }
+        is_chained[i] = true;
+    }
+}
+
+pair<vector<handle_t>, vector<handle_t>>
+HamiltonianChainer::generate_allelic_semiwalks(const HandleGraph& graph,
+                                               const unordered_set<nid_t>& in_phase_nodes,
+                                               const unordered_set<nid_t>& out_phase_nodes,
+                                               const unordered_set<handle_t>& starts,
+                                               const unordered_set<handle_t>& ends
+                                               bool& resolved_hamiltonian) const {
+    
+    pair<vector<handle_t>, vector<handle_t>> return_val;
+    
+    // for reverse iteration (if we need to do it)
+    unordered_set<handle_t> rev_starts, rev_ends;
+    for (auto end : ends) {
+        rev_starts.insert(graph.flip(end));
+    }
+    for (auto start : starts) {
+        rev_ends.insert(graph.flip(start));
+    }
+    
+    auto hamiltonian = find_hamiltonian_path(graph,
+                                             in_phase_nodes,
+                                             out_phase_nodes,
+                                             starts, ends, hamiltonian_max_iters);
+    
+    if (hamiltonian.is_solved && !hamiltonian.hamiltonian_path.empty()) {
+        // this phase can be walked out as a hamiltonian path
+        resolved_hamiltonian = true;
+        
+        // is the hamiltonian unique?
+        bool fully_unique = (hamiltonian.unique_prefix.size() == hamiltonian.hamiltonian_path.size());
+        return_val.first = move(hamiltonian.unique_prefix);
+        
+        if (!fully_unique && !ends.empty()) {
+            // we'll also try to get the unique parts of the other end
+            auto rev_hamiltonian = find_hamiltonian_path(graph,
+                                                         in_phase_nodes,
+                                                         out_phase_nodes,
+                                                         rev_starts, rev_ends, hamiltonian_max_iters);
+            
+            // TODO: does solvability within the max iters guarantee it for the other side?
+            // should I additionally fall back to the unambiguous walk if this fails?
+            if (rev_hamiltonian.is_solved) {
+                // reverse the prefix (to turn it into a suffix) and add it to the return value
+                auto& prefix = rev_hamiltonian.unique_prefix;
+                for (auto it = prefix.rbegin(); it != prefix.rend(); ++it) {
+                    return_val.second.push_back(graph.flip(*it));
+                }
+            }
+        }
+        
+        // TODO: should I treat it as ambiguous if there are cycles that involve the chosen path
+        // (in which case the correct walk might not be Hamiltonian)
+    }
+    else {
+        // fall back on completely unambiguous walks if we can't find a full walk
+        resolved_hamiltonian = false;
+        if (starts.size() == 1) {
+            return_val.first = max_unambiguous_path(graph, *starts.begin(), in_phase_nodes);
+        }
+        if (ends.size() == 1) {
+            auto rev_suffix = max_unambiguous_path(graph, *rev_starts.begin(), in_phase_nodes);
+            for (auto it = rev_suffix.rbegin(); it != rev_suffix.rend(); ++it) {
+                return_val.second.push_back(graph.flip(*it));
+            }
+        }
+    }
+    return return_val;
+}
+
+
+vector<handle_t> HamiltonianChainer::max_unambiguous_path(const HandleGraph& graph, handle_t start,
+                                                          const unordered_set<nid_t>& allowed_nodes) const {
+    
+    vector<handle_t> walk(1, start);
+    bool unambiguous = true;
+    while (unambiguous) {
+        handle_t to_add = as_handle(-1);
+        size_t num_neighbors = 0;
+        unambiguous = graph.follow_edges(walk.back(), false, [&](const handle_t& next) {
+            ++num_neighbors;
+            to_add = next;
+            return num_neighbors == 1 && allowed_nodes.count(graph.get_id(next));
+        });
+        if (num_neighbors != 0 && unambiguous) {
+            walk.push_back(to_add);
+        }
+    }
+    return walk;
+}
+
+vector<handle_t> HamiltonianChainer::walk_diploid_unipath(const HandleGraph& graph, const MultiContactGraph& contact_graph
+                                                          handle_t handle, bool go_left) const {
+    vector<handle_t> unipath(1, handle);
+    while (true) {
+        int degree = 0;
+        handle_t neighbor = as_handle(-1);
+        graph.follow_edges(unipath.back(), go_left, [&](const handle_t& next) {
+            ++degree;
+            neighbor = next;
+            return degree < 2;
+        });
+        if (degree != 1) {
+            break;
+        }
+        degree = 0;
+        graph.follow_edges(neighbor, !go_left, [&](const handle_t& prev) {
+            ++degree;
+            return degree < 2;
+        });
+        if (degree != 1) {
+            break;
+        }
+        if (contact_graph.has_node(graph.get_id(neighbor)) &&
+            contact_graph.has_alt(graph.get_id(neighbor))) {
+            break;
+        }
+        unipath.push_back(neighbor);
+    }
+    if (go_left) {
+        reverse(unipath.begin(), unipath.end());
+    }
+    return unipath;
+}
+
+}

--- a/src/HamiltonianChainer.cpp
+++ b/src/HamiltonianChainer.cpp
@@ -20,7 +20,7 @@ using handlegraph::path_handle_t;
 #include <array>
 #include <algorithm>
 #include <iostream>
-#include <error>
+#include <stdexcept>
 
 using std::vector;
 using std::unordered_set;
@@ -69,7 +69,7 @@ bool HamiltonianChainer::has_phase_chain(const string& name) const {
     if (!path_graph || !path_graph->has_path(name)) {
         return false;
     }
-    path_handle_t path_handle = graph.get_path_handle(name);
+    path_handle_t path_handle = path_graph->get_path_handle(name);
     return (phase_paths[0].count(path_handle) || phase_paths[1].count(path_handle));
 }
 
@@ -77,7 +77,7 @@ int8_t HamiltonianChainer::get_partition(const string& name) const {
     if (!path_graph || !path_graph->has_path(name)) {
         return 0;
     }
-    path_handle_t path_handle = graph.get_path_handle(name);
+    path_handle_t path_handle = path_graph->get_path_handle(name);
     if (phase_paths[0].count(path_handle)) {
         return -1;
     }

--- a/src/HamiltonianPath.cpp
+++ b/src/HamiltonianPath.cpp
@@ -1,0 +1,198 @@
+#include "HamiltonianPath.hpp"
+
+#include <unordered_map>
+#include <limits>
+#include <bitset>
+#include <utility>
+
+using std::unordered_map;
+using std::numeric_limits;
+
+namespace gfase {
+
+HamilonianProblemResult find_hamiltonian_path(const HandleGraph& graph,
+                                              const unordered_set<nid_t>& target_nodes,
+                                              const unordered_set<nid_t>& prohibited_nodes,
+                                              const unordered_set<handle_t>& allowed_starts,
+                                              const unordered_set<handle_t>& allowed_ends,
+                                              size_t max_iters) {
+    
+    HamilonianProblemResult result;
+    
+    unordered_map<handle_t, size_t> handle_number;
+    graph.for_each_handle([&](const handle_t& h) {
+        if (!prohibited_nodes.count(graph.get_id())) {
+            continue;
+        }
+        handle_number[h] = handle_number.size();
+        handle_number[graph.flip(h)] = handle_number.size();
+    });
+    
+    if (handle_number.size() > 64) {
+        // we can't fit the allowed handles into our bitset
+        return result;
+    }
+    
+    function<uint64_t(const handle_t&)> bitcode = [&handle_number](const handle_t& h) {
+        return uint64_t(1) << handle_number[h];
+    };
+    function<bool(uint64_t)> contains_reversal = [](uint64_t set) {
+        // int with alternating bits with 0 in 1s place
+        static const uint64_t altern_0 = 0xaaaaaaaaaaaaaaaa;
+        // int with alternating bits with 1 in 1s place
+        static const uint64_t altern_1 = 0x5555555555555555;
+        // the two strands are always in alternating positions in the sets
+        // so this is only non-zero if they have both 1s set
+        return (set & altern_1) & ((set & altern_0) >> 1);
+    }
+    
+    vector<unordered_set<pair<uint64_t, handle_t>>> dp_table(1);
+    if (allowed_starts.empty()) {
+        // we don't allow unnecesarily long paths, so we still prohibit starting
+        // at an unrequired node
+        for (nid_t node_id : target_nodes) {
+            for (bool reverse : {false, true}) {
+                handle_t handle = graph.get_handle(node_id, reverse);
+                dp_table[0].emplace(bitcode(handle), handle);
+            }
+        }
+    }
+    else {
+        for (handle_t handle : allowed_starts) {
+            dp_table[0].emplace(bitcode(handle), handle));
+        }
+    }
+    
+    // stop if we've hit the longest possible hamiltonian (because we don't allow
+    // traversing both strands of a node) or when there are no hamiltonian paths of
+    // lenght n - 1
+    size_t iter_num = 0;
+    while (dp_table.size() < handle_number.size() / 2 && !dp_table.back().empty()) {
+        
+        dp_table.emplace_back();
+        
+        auto& prev_table = dp_table[dp_table.size() - 2];
+        auto& new_table = dp_table[dp_table.size() - 1];
+        
+        for (const auto& entry : prev_table) {
+            graph.follow_edges(entry.second, false, [&](const handle_t& next) {
+                
+                // TODO: i actually only really need to look for the opposite bitcode,
+                // not any arbitrary reversals...
+                uint64_t new_set = record.first | bitcode(next);
+                if (new_set != entry.first && // was already in set
+                    !contains_reversal(new_set) && // reverse is in set
+                    !prohibited_nodes.count(graph.get_id(next))) {
+                    // extension is valid
+                    new_table.emplace(new_set, next);
+                }
+                
+                // give up if this goes on too long
+                ++iter_num;
+                if (iter_num >= max_iters) {
+                    goto terminate;
+                }
+            });
+        }
+    }
+    
+    // TODO: the popcount instruction might be faster if i switch to 32-bit integers, but
+    // that would require me to template all of this out...
+    
+    uint64_t completion_code = 0;
+    for (nid_t node_id : target_nodes) {
+        for (bool reverse : {true, false}) {
+            completion_code |= bitcode(graph.get_handle(node_id, reverse));
+        }
+    }
+    auto is_complete = [&](uint64_t set) {
+        // c++20 has a template popcount function that could be faster than this, and
+        // there are also non-compiler-dependent algorithms, e.g.
+        // https://stackoverflow.com/questions/109023/count-the-number-of-set-bits-in-a-32-bit-integer
+        return bitset<64>(set & completion_code).count() == target_nodes.size();
+    };
+    
+    
+    // traceback routine
+    
+    // all of the DP entrys that are part of a traceback in each step
+    vector<unordered_set<pair<uint64_t, handle_t>>> traceback_clouds(dp_table.size());
+    // a single traceback
+    vector<pair<uint64_t, handle_t>> traceback;
+    for (int64_t i = dp_table.size() - 1; i >= 0; --i) {
+        
+        auto& table = dp_table[i];
+        auto& cloud = traceback_clouds[i];
+        
+        // find complete, valid hamiltonian paths
+        // we only allow the path to end in a non-target node if that node was provided as a
+        // an allowed end (this prevents unnecessary elongation into non-target nodes)
+        // it must also not be a part of a traceback that we're already extending
+        for (const auto& entry : table) {
+            if ((allowed_ends.empty() || allowed_ends.count(entry.second)) &&
+                (allowed_ends.count(entry.second) || target_nodes.count(graph.get_id(entry.second))) &&
+                !cloud.count(entry) &&
+                is_complete(entry.first)) {
+                
+                ++num_endings_found[i];
+                traceback_clouds[i].emplace(entry);
+                
+                // we always start the single traceback over if we find a new ending, this ensures
+                // that we get the shortest possible path
+                traceback.clear();
+                traceback.push_back(entry);
+            }
+        }
+        
+        if (i > 0) {
+            // try to find a predecessor for the ongoing tracebacks
+            auto& prev_table = dp_table[i - 1];
+            auto& prev_cloud = traceback_clouds[i - 1];
+            
+            for (const auto& dp_entry : cloud) {
+                // remove the final node's bit
+                uint64_t prev_set = dp_entry.first ^ bitcode(dp_entry.second);
+                graph.follow_edges(dp_entry.second, true, [&](const handle_t& prev) {
+                    auto prev_entry = make_pair(prev_set, prev)
+                    if (prev_table.count(prev_entry)) {
+                        prev_cloud.emplace(prev_entry);
+                    }
+                    if (!traceback.empty() && dp_entry == traceback.back()) {
+                        traceback.push_back(prev_entry);
+                    }
+                });
+            }
+        }
+    }
+        
+    // FIXME: we will never get a unique hamiltonian if we don't specify any starts or ends
+    // because the orientation can be reversed. we need to break symmetry by insisting on
+    // a particular strand for one required node
+    
+    result.is_solved = true;
+    if (!traceback.empty()) {
+        // populate the path in the result
+        for (auto it = traceback.rbegin(); it != traceback.rend(); ++it) {
+            result.hamiltonian_path.push_back(it->second);
+        }
+        // check for uniqueness
+        result.is_unique = true;
+        for (size_t i = 0; i < traceback_clouds.size(); ++i) {
+            if (traceback_clouds[i].size() > 1) {
+                result.is_unique = false;
+                // record how much of the prefix is unique (if any)
+                for (size_t j = 0; j < i; ++j) {
+                    result.unique_prefix.push_back(traceback_clouds[j].begin()->first);
+                }
+                break;
+            }
+        }
+    }
+    
+    // we skip to the end if we run into the maximum number of iterations in the inner loop
+terminate:
+    
+    return result;
+}
+
+}

--- a/src/HamiltonianPath.cpp
+++ b/src/HamiltonianPath.cpp
@@ -7,6 +7,10 @@
 
 using std::unordered_map;
 using std::numeric_limits;
+using std::function;
+using std::pair;
+using std::bitset;
+using std::make_pair;
 
 namespace gfase {
 
@@ -21,8 +25,8 @@ HamilonianProblemResult find_hamiltonian_path(const HandleGraph& graph,
     
     unordered_map<handle_t, size_t> handle_number;
     graph.for_each_handle([&](const handle_t& h) {
-        if (!prohibited_nodes.count(graph.get_id())) {
-            continue;
+        if (!prohibited_nodes.count(graph.get_id(h))) {
+            return;
         }
         handle_number[h] = handle_number.size();
         handle_number[graph.flip(h)] = handle_number.size();
@@ -44,7 +48,7 @@ HamilonianProblemResult find_hamiltonian_path(const HandleGraph& graph,
         // the two strands are always in alternating positions in the sets
         // so this is only non-zero if they have both 1s set
         return (set & altern_1) & ((set & altern_0) >> 1);
-    }
+    };
     
     vector<unordered_set<pair<uint64_t, handle_t>>> dp_table(1);
     if (allowed_starts.empty()) {
@@ -59,7 +63,7 @@ HamilonianProblemResult find_hamiltonian_path(const HandleGraph& graph,
     }
     else {
         for (handle_t handle : allowed_starts) {
-            dp_table[0].emplace(bitcode(handle), handle));
+            dp_table[0].emplace(bitcode(handle), handle);
         }
     }
     
@@ -67,7 +71,8 @@ HamilonianProblemResult find_hamiltonian_path(const HandleGraph& graph,
     // traversing both strands of a node) or when there are no hamiltonian paths of
     // lenght n - 1
     size_t iter_num = 0;
-    while (dp_table.size() < handle_number.size() / 2 && !dp_table.back().empty()) {
+    while (dp_table.size() < handle_number.size() / 2 && !dp_table.back().empty()
+           && iter_num < max_iters) {
         
         dp_table.emplace_back();
         
@@ -75,11 +80,11 @@ HamilonianProblemResult find_hamiltonian_path(const HandleGraph& graph,
         auto& new_table = dp_table[dp_table.size() - 1];
         
         for (const auto& entry : prev_table) {
-            graph.follow_edges(entry.second, false, [&](const handle_t& next) {
+            bool keep_going = graph.follow_edges(entry.second, false, [&](const handle_t& next) {
                 
                 // TODO: i actually only really need to look for the opposite bitcode,
                 // not any arbitrary reversals...
-                uint64_t new_set = record.first | bitcode(next);
+                uint64_t new_set = entry.first | bitcode(next);
                 if (new_set != entry.first && // was already in set
                     !contains_reversal(new_set) && // reverse is in set
                     !prohibited_nodes.count(graph.get_id(next))) {
@@ -89,109 +94,109 @@ HamilonianProblemResult find_hamiltonian_path(const HandleGraph& graph,
                 
                 // give up if this goes on too long
                 ++iter_num;
-                if (iter_num >= max_iters) {
-                    goto terminate;
-                }
+                return iter_num < max_iters;
             });
-        }
-    }
-    
-    // TODO: the popcount instruction might be faster if i switch to 32-bit integers, but
-    // that would require me to template all of this out...
-    
-    uint64_t completion_code = 0;
-    for (nid_t node_id : target_nodes) {
-        for (bool reverse : {true, false}) {
-            completion_code |= bitcode(graph.get_handle(node_id, reverse));
-        }
-    }
-    auto is_complete = [&](uint64_t set) {
-        // c++20 has a template popcount function that could be faster than this, and
-        // there are also non-compiler-dependent algorithms, e.g.
-        // https://stackoverflow.com/questions/109023/count-the-number-of-set-bits-in-a-32-bit-integer
-        return bitset<64>(set & completion_code).count() == target_nodes.size();
-    };
-    
-    
-    // traceback routine
-    
-    // all of the DP entrys that are part of a traceback in each step
-    vector<unordered_set<pair<uint64_t, handle_t>>> traceback_clouds(dp_table.size());
-    // a single traceback
-    vector<pair<uint64_t, handle_t>> traceback;
-    for (int64_t i = dp_table.size() - 1; i >= 0; --i) {
-        
-        auto& table = dp_table[i];
-        auto& cloud = traceback_clouds[i];
-        
-        // find complete, valid hamiltonian paths
-        // we only allow the path to end in a non-target node if that node was provided as a
-        // an allowed end (this prevents unnecessary elongation into non-target nodes)
-        // it must also not be a part of a traceback that we're already extending
-        for (const auto& entry : table) {
-            if ((allowed_ends.empty() || allowed_ends.count(entry.second)) &&
-                (allowed_ends.count(entry.second) || target_nodes.count(graph.get_id(entry.second))) &&
-                !cloud.count(entry) &&
-                is_complete(entry.first)) {
-                
-                ++num_endings_found[i];
-                traceback_clouds[i].emplace(entry);
-                
-                // we always start the single traceback over if we find a new ending, this ensures
-                // that we get the shortest possible path
-                traceback.clear();
-                traceback.push_back(entry);
-            }
-        }
-        
-        if (i > 0) {
-            // try to find a predecessor for the ongoing tracebacks
-            auto& prev_table = dp_table[i - 1];
-            auto& prev_cloud = traceback_clouds[i - 1];
-            
-            for (const auto& dp_entry : cloud) {
-                // remove the final node's bit
-                uint64_t prev_set = dp_entry.first ^ bitcode(dp_entry.second);
-                graph.follow_edges(dp_entry.second, true, [&](const handle_t& prev) {
-                    auto prev_entry = make_pair(prev_set, prev)
-                    if (prev_table.count(prev_entry)) {
-                        prev_cloud.emplace(prev_entry);
-                    }
-                    if (!traceback.empty() && dp_entry == traceback.back()) {
-                        traceback.push_back(prev_entry);
-                    }
-                });
-            }
-        }
-    }
-        
-    // FIXME: we will never get a unique hamiltonian if we don't specify any starts or ends
-    // because the orientation can be reversed. we need to break symmetry by insisting on
-    // a particular strand for one required node
-    
-    result.is_solved = true;
-    if (!traceback.empty()) {
-        // populate the path in the result
-        for (auto it = traceback.rbegin(); it != traceback.rend(); ++it) {
-            result.hamiltonian_path.push_back(it->second);
-        }
-        // check for uniqueness
-        result.is_unique = true;
-        for (size_t i = 0; i < traceback_clouds.size(); ++i) {
-            if (traceback_clouds[i].size() > 1) {
-                result.is_unique = false;
-                // record how much of the prefix is unique (if any)
-                for (size_t j = 0; j < i; ++j) {
-                    result.unique_prefix.push_back(traceback_clouds[j].begin()->first);
-                }
+            if (!keep_going) {
                 break;
             }
         }
     }
     
-    // we skip to the end if we run into the maximum number of iterations in the inner loop
-terminate:
+    if (iter_num < max_iters) {
+        
+        // TODO: the popcount instruction might be faster if i switch to 32-bit integers, but
+        // that would require me to template all of this out...
+        
+        uint64_t completion_code = 0;
+        for (nid_t node_id : target_nodes) {
+            for (bool reverse : {true, false}) {
+                completion_code |= bitcode(graph.get_handle(node_id, reverse));
+            }
+        }
+        auto is_complete = [&](uint64_t set) {
+            // c++20 has a template popcount function that could be faster than this, and
+            // there are also non-compiler-dependent algorithms, e.g.
+            // https://stackoverflow.com/questions/109023/count-the-number-of-set-bits-in-a-32-bit-integer
+            return bitset<64>(set & completion_code).count() == target_nodes.size();
+        };
+        
+        // traceback routine
+        
+        // all of the DP entrys that are part of a traceback in each step
+        vector<unordered_set<pair<uint64_t, handle_t>>> traceback_clouds(dp_table.size());
+        // a single traceback
+        vector<pair<uint64_t, handle_t>> traceback;
+        for (int64_t i = dp_table.size() - 1; i >= 0; --i) {
+            
+            auto& table = dp_table[i];
+            auto& cloud = traceback_clouds[i];
+            
+            // find complete, valid hamiltonian paths
+            // we only allow the path to end in a non-target node if that node was provided as a
+            // an allowed end (this prevents unnecessary elongation into non-target nodes)
+            // it must also not be a part of a traceback that we're already extending
+            for (const auto& entry : table) {
+                if ((allowed_ends.empty() || allowed_ends.count(entry.second)) &&
+                    (allowed_ends.count(entry.second) || target_nodes.count(graph.get_id(entry.second))) &&
+                    !cloud.count(entry) &&
+                    is_complete(entry.first)) {
+                    
+                    traceback_clouds[i].emplace(entry);
+                    
+                    // we always start the single traceback over if we find a new ending, this ensures
+                    // that we get the shortest possible path
+                    traceback.clear();
+                    traceback.push_back(entry);
+                }
+            }
+            
+            if (i > 0) {
+                // try to find a predecessor for the ongoing tracebacks
+                auto& prev_table = dp_table[i - 1];
+                auto& prev_cloud = traceback_clouds[i - 1];
+                
+                for (const auto& dp_entry : cloud) {
+                    // remove the final node's bit
+                    uint64_t prev_set = dp_entry.first ^ bitcode(dp_entry.second);
+                    graph.follow_edges(dp_entry.second, true, [&](const handle_t& prev) {
+                        auto prev_entry = make_pair(prev_set, prev);
+                        if (prev_table.count(prev_entry)) {
+                            prev_cloud.emplace(prev_entry);
+                        }
+                        if (!traceback.empty() && dp_entry == traceback.back()) {
+                            traceback.push_back(prev_entry);
+                        }
+                    });
+                }
+            }
+        }
+        
+        // FIXME: we will never get a unique hamiltonian if we don't specify any starts or ends
+        // because the orientation can be reversed. we need to break symmetry by insisting on
+        // a particular strand for one required node
+        
+        result.is_solved = true;
+        if (!traceback.empty()) {
+            // populate the path in the result
+            for (auto it = traceback.rbegin(); it != traceback.rend(); ++it) {
+                result.hamiltonian_path.push_back(it->second);
+            }
+            // check for uniqueness
+            result.is_unique = true;
+            for (size_t i = 0; i < traceback_clouds.size(); ++i) {
+                if (traceback_clouds[i].size() > 1) {
+                    result.is_unique = false;
+                    // record how much of the prefix is unique (if any)
+                    for (size_t j = 0; j < i; ++j) {
+                        result.unique_prefix.push_back(traceback_clouds[j].begin()->second);
+                    }
+                    break;
+                }
+            }
+        }
+    }
     
+    // we skip to the end if we run into the maximum number of iterations in the inner loop
     return result;
 }
 

--- a/src/HamiltonianPath.cpp
+++ b/src/HamiltonianPath.cpp
@@ -178,22 +178,21 @@ HamilonianProblemResult find_hamiltonian_path(const HandleGraph& graph,
         result.is_solved = true;
         if (!traceback.empty()) {
             // populate the path in the result
+            bool found_non_unique = false;
+            size_t i = traceback.size() - 1;
             for (auto it = traceback.rbegin(); it != traceback.rend(); ++it) {
+                
                 result.hamiltonian_path.push_back(it->second);
-            }
-            // check for uniqueness
-            result.is_unique = true;
-            for (size_t i = 0; i < traceback_clouds.size(); ++i) {
-                if (traceback_clouds[i].size() > 1) {
-                    result.is_unique = false;
-                    // record how much of the prefix is unique (if any)
-                    for (size_t j = 0; j < i; ++j) {
-                        result.unique_prefix.push_back(traceback_clouds[j].begin()->second);
-                    }
-                    break;
+                
+                // check for uniqueness
+                found_non_unique = found_non_unique || traceback_clouds[i].size() <= 1;
+                if (!found_non_unique) {
+                    result.unique_prefix.push_back(it->second);
                 }
+                --i;
             }
         }
+        
     }
     
     // we skip to the end if we run into the maximum number of iterations in the inner loop

--- a/src/SubgraphOverlay.cpp
+++ b/src/SubgraphOverlay.cpp
@@ -1,0 +1,100 @@
+#include <atomic>
+#include "SubgraphOverlay.hpp"
+
+namespace gfase {
+
+SubgraphOverlay::SubgraphOverlay(const HandleGraph& backing, const unordered_set<nid_t>& node_subset) :
+    backing_graph(&backing),
+    node_subset(&node_subset) {
+    if (!node_subset->empty()) {
+        auto minmax_nodes = std::minmax_element(node_subset->begin(), node_subset->end());
+        min_node = *minmax_nodes.first;
+        max_node = *minmax_nodes.second;
+    } 
+}
+
+SubgraphOverlay::~SubgraphOverlay() {
+    
+}
+
+bool SubgraphOverlay::has_node(nid_t node_id) const {
+    return node_subset->count(node_id);
+}
+   
+handle_t SubgraphOverlay::get_handle(const nid_t& node_id, bool is_reverse) const {
+    if (has_node(node_id)) {
+        return backing_graph->get_handle(node_id, is_reverse);
+    } else {
+        throw runtime_error("Node " + std::to_string(node_id) + " not in subgraph overlay");
+    }
+}
+    
+nid_t SubgraphOverlay::get_id(const handle_t& handle) const {
+    return backing_graph->get_id(handle);
+}
+    
+bool SubgraphOverlay::get_is_reverse(const handle_t& handle) const {
+    return backing_graph->get_is_reverse(handle);
+}
+
+handle_t SubgraphOverlay::flip(const handle_t& handle) const {
+    return backing_graph->flip(handle);
+}
+    
+size_t SubgraphOverlay::get_length(const handle_t& handle) const {
+    return backing_graph->get_length(handle);
+}
+
+std::string SubgraphOverlay::get_sequence(const handle_t& handle) const {
+    return backing_graph->get_sequence(handle);
+}
+    
+size_t SubgraphOverlay::get_node_count() const {
+    return node_subset->size();
+}
+
+nid_t SubgraphOverlay::min_node_id() const {
+    return min_node;
+}
+    
+nid_t SubgraphOverlay::max_node_id() const {
+    return max_node;
+}
+
+bool SubgraphOverlay::follow_edges_impl(const handle_t& handle, bool go_left, const std::function<bool(const handle_t&)>& iteratee) const {
+    
+    std::function<bool(const handle_t&)> subgraph_iteratee = [&](const handle_t& handle) {
+        if (has_node(backing_graph->get_id(handle))) {
+            if (!iteratee(handle)) {
+                return false;
+            }
+        }
+        return true;
+    };
+    if (has_node(backing_graph->get_id(handle))) {
+        return backing_graph->follow_edges(handle, go_left, subgraph_iteratee);
+    }
+    return true;
+}
+    
+bool SubgraphOverlay::for_each_handle_impl(const std::function<bool(const handle_t&)>& iteratee, bool parallel) const {
+
+    if (!parallel) {
+        bool keep_going = true;
+        for (auto node_it = node_subset->begin(); keep_going && node_it != node_subset->end(); ++node_it) {
+            keep_going = iteratee(get_handle(*node_it, false));
+        }
+        return keep_going;
+    } else {
+        // copy them into something easy to iterate with omp
+        vector<nid_t> node_vec(node_subset->begin(), node_subset->end());
+        std::atomic<bool> keep_going(true);
+#pragma omp parallel for
+        for (size_t i = 0; i < node_vec.size(); ++i) {
+            keep_going = keep_going && iteratee(backing_graph->get_handle(node_vec[i]));
+        }
+        return keep_going;
+    }
+}
+
+}

--- a/src/SubgraphOverlay.cpp
+++ b/src/SubgraphOverlay.cpp
@@ -1,11 +1,16 @@
-#include <atomic>
 #include "SubgraphOverlay.hpp"
+
+#include <atomic>
+#include <vector>
 
 namespace gfase {
 
-SubgraphOverlay::SubgraphOverlay(const HandleGraph& backing, const unordered_set<nid_t>& node_subset) :
-    backing_graph(&backing),
-    node_subset(&node_subset) {
+using std::vector;
+using std::runtime_error;
+
+SubgraphOverlay::SubgraphOverlay(const HandleGraph* backing, const unordered_set<nid_t>* node_subset) :
+    backing_graph(backing),
+    node_subset(node_subset) {
     if (!node_subset->empty()) {
         auto minmax_nodes = std::minmax_element(node_subset->begin(), node_subset->end());
         min_node = *minmax_nodes.first;

--- a/src/executable/phase_contacts_with_monte_carlo.cpp
+++ b/src/executable/phase_contacts_with_monte_carlo.cpp
@@ -527,8 +527,7 @@ void phase(
     contact_graph.write_bandage_csv(phases_output_path, id_map);
 
     chainer->generate_chain_paths(graph, id_map, contact_graph);
-    // TODO: Jordan is disabling this for now, because the concept doesn't generalize to both chainers
-    //chainer.write_chainable_nodes_to_bandage_csv(output_dir, id_map);
+    chainer->write_chaining_results_to_bandage_csv(output_dir, id_map);
 
     cerr << t << "Writing GFA... " << '\n';
 
@@ -611,6 +610,10 @@ int main (int argc, char* argv[]){
             use_homology,
             "(Default = " + to_string(use_homology) + ")\tUse sequence homology to find alts. For whenever the GFA does not have Shasta node labels.");
 
+    app.add_flag(
+            "--use_hamiltonian_chainer",
+            use_hamiltonian_chainer,
+            "(Default = " + to_string(use_hamiltonian_chainer) + ")\tBuild chains using Hamiltonian paths of bridge components instead of simple bubbles.");
     app.add_flag(
             "--skip_unzip",
             skip_unzip,

--- a/src/graph_utility.cpp
+++ b/src/graph_utility.cpp
@@ -202,6 +202,14 @@ void for_each_connected_component(HandleGraph& graph, const function<void(unorde
     }
 }
 
+void for_each_connected_component_subgraph(HandleGraph& graph,
+                                           const function<void(const HandleGraph& subgraph)>& f) {
+    for_each_connected_component(graph, [&](unordered_set<nid_t>& connected_component) {
+        f(SubgraphOverlay(graph, connected_component));
+    });
+}
+
+
 /// For any 2 graphs with corresponding id maps, take a handle from the source graph and translate it into
 /// an id in the destination graph, adding it to the destination id_map if it does not yet exist.
 /// Then, return the id of the handle in source and destination as a pair

--- a/src/graph_utility.cpp
+++ b/src/graph_utility.cpp
@@ -205,7 +205,7 @@ void for_each_connected_component(HandleGraph& graph, const function<void(unorde
 void for_each_connected_component_subgraph(HandleGraph& graph,
                                            const function<void(const HandleGraph& subgraph)>& f) {
     for_each_connected_component(graph, [&](unordered_set<nid_t>& connected_component) {
-        f(SubgraphOverlay(graph, connected_component));
+        f(SubgraphOverlay(&graph, &connected_component));
     });
 }
 

--- a/src/test/test_bridges.cpp
+++ b/src/test/test_bridges.cpp
@@ -1,0 +1,109 @@
+#include "Bridges.hpp"
+#include "IncrementalIdMap.hpp"
+#include "gfa_to_handle.hpp"
+#include "handle_to_gfa.hpp"
+#include "graph_utility.hpp"
+#include "Filesystem.hpp"
+
+#include "bdsg/hash_graph.hpp"
+
+#include <string>
+#include <set>
+
+using gfase::IncrementalIdMap;
+using gfase::handle_graph_to_gfa;
+using gfase::for_node_in_bfs;
+using gfase::for_edge_in_bfs;
+
+using ghc::filesystem::path;
+using bdsg::HashGraph;
+using handlegraph::handle_t;
+
+using std::string;
+
+int main(){
+
+    auto get_bridge_names = [&](string data_file) {
+        
+        path script_path = __FILE__;
+        path project_directory = script_path.parent_path().parent_path().parent_path();
+        path relative_gfa_path = data_file;
+        path absolute_gfa_path = project_directory / relative_gfa_path;
+        
+        GfaReader reader(absolute_gfa_path);
+        
+        HashGraph graph;
+        IncrementalIdMap<string> id_map;
+        
+        gfa_to_handle_graph(graph, id_map, absolute_gfa_path);
+        
+        set<string> bridge_names;
+        for_each_connected_component_subgraph(graph, [&](const HandleGraph& component) {
+            for (auto bridge : bridge_nodes(component)) {
+                bridge_names.insert(id_map.get_name(bridge));
+            }
+        });
+        return bridge_names;
+    }
+    
+    {
+        string file = "data/simple_chain.gfa";
+        
+        set<string> bridge_names = get_bridge_names(file);
+        
+        set<string> correct_names{"i", "j", "k", "l", "m"};
+        
+        if (bridge_names != correct_names) {
+            throw runtime_error(("ERROR: incorrect bridges detected in GFA " + file).c_str());
+        }
+    }
+    
+    {
+        string file = "data/test_gfa1.gfa";
+        
+        set<string> bridge_names = get_bridge_names(file);
+        
+        set<string> correct_names{"11", "13"};
+        
+        if (bridge_names != correct_names) {
+            throw runtime_error(("ERROR: incorrect bridges detected in GFA " + file).c_str());
+        }
+    }
+    
+    {
+        string file = "data/connected_components.gfa";
+        
+        set<string> bridge_names = get_bridge_names(file);
+        
+        set<string> correct_names{"a", "d", "e", "f", "g", "h"};
+        
+        if (bridge_names != correct_names) {
+            throw runtime_error(("ERROR: incorrect bridges detected in GFA " + file).c_str());
+        }
+    }
+    
+    {
+        string file = "data/chain_test.gfa";
+        
+        set<string> bridge_names = get_bridge_names(file);
+        
+        // by component
+        set<string> correct_names{
+            "a", "d", "g_a", "g_b", "j", "m", "n", "p", "s", "t", "tip_a", "tip_d", "tip_e", "tip_f",
+            "a2", "d2", "g2", "j2", "m2_0", "m2_1", "q2_0", "q2_1", "x2",
+            "diploid_a0", "diploid_a1", "triploid_e0", "triploid_e1", "triploid_e2",
+            "unique",
+            "unphased_mat",
+            "unphased_pat",
+            "tree_a", "tree_e",
+            "a3", "d3", "g3", "j3", "m3",
+            "a4", "g4", "j4", "m4"
+        };
+        
+        if (bridge_names != correct_names) {
+            throw runtime_error(("ERROR: incorrect bridges detected in GFA " + file).c_str());
+        }
+    }
+
+    return 0;
+}

--- a/src/test/test_bridges.cpp
+++ b/src/test/test_bridges.cpp
@@ -10,10 +10,7 @@
 #include <string>
 #include <set>
 
-using gfase::IncrementalIdMap;
-using gfase::handle_graph_to_gfa;
-using gfase::for_node_in_bfs;
-using gfase::for_edge_in_bfs;
+using namespace gfase;
 
 using ghc::filesystem::path;
 using bdsg::HashGraph;
@@ -40,11 +37,11 @@ int main(){
         set<string> bridge_names;
         for_each_connected_component_subgraph(graph, [&](const HandleGraph& component) {
             for (auto bridge : bridge_nodes(component)) {
-                bridge_names.insert(id_map.get_name(bridge));
+                bridge_names.insert(id_map.get_name(graph.get_id(bridge)));
             }
         });
         return bridge_names;
-    }
+    };
     
     {
         string file = "data/simple_chain.gfa";

--- a/src/test/test_bridges.cpp
+++ b/src/test/test_bridges.cpp
@@ -9,6 +9,8 @@
 
 #include <string>
 #include <set>
+#include <iostream>
+#include <algorithm>
 
 using namespace gfase;
 
@@ -16,91 +18,72 @@ using ghc::filesystem::path;
 using bdsg::HashGraph;
 using handlegraph::handle_t;
 
+using std::sort;
 using std::string;
+using std::cerr;
+using std::endl;
+
+void run_test(string& data_file, set<string>& correct_names) {
+    
+    path script_path = __FILE__;
+    path project_directory = script_path.parent_path().parent_path().parent_path();
+    path relative_gfa_path = data_file;
+    path absolute_gfa_path = project_directory / relative_gfa_path;
+    
+    GfaReader reader(absolute_gfa_path);
+    
+    HashGraph graph;
+    IncrementalIdMap<string> id_map;
+    
+    gfa_to_handle_graph(graph, id_map, absolute_gfa_path);
+    
+    set<string> bridge_names;
+    for_each_connected_component_subgraph(graph, [&](const HandleGraph& component) {
+        for (auto bridge : bridge_nodes(component)) {
+            bridge_names.insert(id_map.get_name(graph.get_id(bridge)));
+        }
+    });
+    
+    if (bridge_names != correct_names) {
+        throw runtime_error(("ERROR: incorrect bridges detected in GFA " + data_file).c_str());
+    }
+}
 
 int main(){
 
-    auto get_bridge_names = [&](string data_file) {
-        
-        path script_path = __FILE__;
-        path project_directory = script_path.parent_path().parent_path().parent_path();
-        path relative_gfa_path = data_file;
-        path absolute_gfa_path = project_directory / relative_gfa_path;
-        
-        GfaReader reader(absolute_gfa_path);
-        
-        HashGraph graph;
-        IncrementalIdMap<string> id_map;
-        
-        gfa_to_handle_graph(graph, id_map, absolute_gfa_path);
-        
-        set<string> bridge_names;
-        for_each_connected_component_subgraph(graph, [&](const HandleGraph& component) {
-            for (auto bridge : bridge_nodes(component)) {
-                bridge_names.insert(id_map.get_name(graph.get_id(bridge)));
-            }
-        });
-        return bridge_names;
-    };
-    
     {
         string file = "data/simple_chain.gfa";
-        
-        set<string> bridge_names = get_bridge_names(file);
-        
         set<string> correct_names{"i", "j", "k", "l", "m"};
-        
-        if (bridge_names != correct_names) {
-            throw runtime_error(("ERROR: incorrect bridges detected in GFA " + file).c_str());
-        }
+        run_test(file, correct_names);
     }
-    
     {
         string file = "data/test_gfa1.gfa";
-        
-        set<string> bridge_names = get_bridge_names(file);
-        
         set<string> correct_names{"11", "13"};
-        
-        if (bridge_names != correct_names) {
-            throw runtime_error(("ERROR: incorrect bridges detected in GFA " + file).c_str());
-        }
+        run_test(file, correct_names);
     }
-    
     {
         string file = "data/connected_components.gfa";
-        
-        set<string> bridge_names = get_bridge_names(file);
-        
         set<string> correct_names{"a", "d", "e", "f", "g", "h"};
-        
-        if (bridge_names != correct_names) {
-            throw runtime_error(("ERROR: incorrect bridges detected in GFA " + file).c_str());
-        }
+        run_test(file, correct_names);
     }
-    
     {
         string file = "data/chain_test.gfa";
-        
-        set<string> bridge_names = get_bridge_names(file);
-        
         // by component
         set<string> correct_names{
-            "a", "d", "g_a", "g_b", "j", "m", "n", "p", "s", "t", "tip_a", "tip_d", "tip_e", "tip_f",
-            "a2", "d2", "g2", "j2", "m2_0", "m2_1", "q2_0", "q2_1", "x2",
+            "a", "d", "g_a", "g_b", "j", "m", "n", "o", "p", "s", "t", "tip_a", "tip_d", "tip_e", "tip_f",
+            "a2", "d2", "j2", "m2_0", "m2_1", "q2_0", "q2_1", "x2",
             "diploid_a0", "diploid_a1", "triploid_e0", "triploid_e1", "triploid_e2",
             "unique",
             "unphased_mat",
             "unphased_pat",
             "tree_a", "tree_e",
-            "a3", "d3", "g3", "j3", "m3",
-            "a4", "g4", "j4", "m4"
+            "a3", "d3", "g3", "j3",
+            "a4", "g4", "j4"
         };
-        
-        if (bridge_names != correct_names) {
-            throw runtime_error(("ERROR: incorrect bridges detected in GFA " + file).c_str());
-        }
+        run_test(file, correct_names);
     }
 
+    cerr << "All tests successful!" << endl;
+    
     return 0;
 }

--- a/src/test/test_bridges.cpp
+++ b/src/test/test_bridges.cpp
@@ -23,7 +23,9 @@ using std::string;
 using std::cerr;
 using std::endl;
 
-void run_test(string& data_file, set<string>& correct_names) {
+void run_test(string& data_file,
+              set<string>& correct_bridge_names,
+              set<set<string>>& correct_bridge_components) {
     
     path script_path = __FILE__;
     path project_directory = script_path.parent_path().parent_path().parent_path();
@@ -37,15 +39,36 @@ void run_test(string& data_file, set<string>& correct_names) {
     
     gfa_to_handle_graph(graph, id_map, absolute_gfa_path);
     
+    vector<handle_t> bridges;
     set<string> bridge_names;
     for_each_connected_component_subgraph(graph, [&](const HandleGraph& component) {
         for (auto bridge : bridge_nodes(component)) {
+            bridges.push_back(bridge);
             bridge_names.insert(id_map.get_name(graph.get_id(bridge)));
         }
     });
     
-    if (bridge_names != correct_names) {
+    if (bridge_names != correct_bridge_names) {
         throw runtime_error(("ERROR: incorrect bridges detected in GFA " + data_file).c_str());
+    }
+    
+    auto consolidated_bridges = consolidate_bridges(graph, bridges);
+    
+    set<set<string>> bridge_components;
+    for_each_bridge_component(graph, consolidated_bridges,
+                              [&](const HandleGraph& graph,
+                                  const vector<pair<size_t, bool>>& incident_bridges) {
+        set<string> component;
+        
+        graph.for_each_handle([&](const handle_t& handle) {
+            component.insert(id_map.get_name(graph.get_id(handle)));
+        });
+        
+        bridge_components.insert(component);
+    });
+    
+    if (bridge_components != correct_bridge_components) {
+        throw runtime_error(("ERROR: incorrect bridge components detected in GFA " + data_file).c_str());
     }
 }
 
@@ -54,21 +77,42 @@ int main(){
     {
         string file = "data/simple_chain.gfa";
         set<string> correct_names{"i", "j", "k", "l", "m"};
-        run_test(file, correct_names);
+        set<set<string>> correct_components{
+            {"i"},
+            {"m"},
+            {"g", "h", "l", "m"},
+            {"e", "f", "k", "l"},
+            {"c", "d", "j", "k"},
+            {"a", "b", "i", "j"}
+        };
+        run_test(file, correct_names, correct_components);
     }
     {
         string file = "data/test_gfa1.gfa";
         set<string> correct_names{"11", "13"};
-        run_test(file, correct_names);
+        set<set<string>> correct_components{
+            {"11", "12", "13"},
+            {"11"},
+            {"13"}
+        };
+        run_test(file, correct_names, correct_components);
     }
     {
         string file = "data/connected_components.gfa";
         set<string> correct_names{"a", "d", "e", "f", "g", "h"};
-        run_test(file, correct_names);
+        set<set<string>> correct_components{
+            {"a", "b", "c", "d"},
+            {"a"},
+            {"d"},
+            {"g"},
+            {"h"},
+            {"e"},
+            {"f"}
+        };
+        run_test(file, correct_names, correct_components);
     }
     {
         string file = "data/chain_test.gfa";
-        // by component
         set<string> correct_names{
             "a", "d", "g_a", "g_b", "j", "m", "n", "o", "p", "s", "t", "tip_a", "tip_d", "tip_e", "tip_f",
             "a2", "d2", "j2", "m2_0", "m2_1", "q2_0", "q2_1", "x2",
@@ -80,7 +124,18 @@ int main(){
             "a3", "d3", "g3", "j3",
             "a4", "g4", "j4"
         };
-        run_test(file, correct_names);
+        set<set<string>> correct_components{
+            {"s"}, {"t"}, {"p", "q", "r", "s", "t"}, {"n"}, {"n", "o", "p"}, {"j", "k", "l", "m"}, {"g_b", "h", "i", "j"}, {"g_a", "g_b", "tip_a"}, {"tip_a", "tip_b", "tip_c", "tip_d"}, {"tip_d", "tip_e", "tip_f"}, {"tip_f"}, {"tip_e"}, {"d", "e", "f", "g_a"}, {"a", "b", "c", "d"}, {"a"},
+            {"triploid_e1"}, {"triploid_e0"}, {"triploid_e2"}, {"diploid_a0", "diploid_a1", "diploid_b0", "diploid_b1", "diploid_c0", "diploid_c1", "diploid_d0", "diploid_d1", "diploid_e0", "diploid_e1", "triploid_e0", "triploid_e1", "triploid_e2"}, {"diploid_a1"}, {"diploid_a0"},
+            {"q2_0"}, {"m2_0", "o2_0", "p2_0", "q2_0"}, {"k2_0", "k2_1", "l2_0", "l2_1", "m2_0", "m2_1", "x2"}, {"m2_1", "o2_1", "p2_1", "q2_1"}, {"q2_1"}, {"d2", "e2", "f2", "g2", "h2", "i2", "j2"}, {"a2", "b2", "c2", "d2"}, {"a2"},
+            {"tree_e"}, {"tree_a", "tree_b0", "tree_b1", "tree_c0", "tree_c1", "tree_c2", "tree_c3", "tree_d0", "tree_d1", "tree_e"}, {"tree_a"},
+            {"a3"}, {"a3", "b3", "c3", "d3"}, {"d3", "e3", "f3", "g3"}, {"g3", "h3", "i3", "j3"}, {"j3", "k3", "l3", "m3"},
+            {"a4"}, {"a4", "b4", "c4", "e4", "f4", "g4"}, {"g4", "h4", "i4", "j4"}, {"j4", "k4", "l4", "m4"},
+            {"unique"},
+            {"unphased_mat"},
+            {"unphased_pat"}
+        };
+        run_test(file, correct_names, correct_components);
     }
 
     cerr << "All tests successful!" << endl;

--- a/src/test/test_chainer.cpp
+++ b/src/test/test_chainer.cpp
@@ -97,7 +97,7 @@ void chain(path output_dir, path gfa_path){
 
     unzip(graph, id_map, false, false);
 
-    chainer.write_chainable_nodes_to_bandage_csv(output_dir, id_map);
+    chainer.write_chaining_results_to_bandage_csv(output_dir, id_map);
 
     path unzipped_gfa_path = output_dir / "unzipped.gfa";
     ofstream unzipped_gfa(unzipped_gfa_path);

--- a/src/test/test_hamiltonian_chainer.cpp
+++ b/src/test/test_hamiltonian_chainer.cpp
@@ -1,0 +1,108 @@
+#include "HamiltonianChainer.hpp"
+#include "IncrementalIdMap.hpp"
+#include "MultiContactGraph.hpp"
+#include "gfa_to_handle.hpp"
+#include "handle_to_gfa.hpp"
+#include "graph_utility.hpp"
+#include "Filesystem.hpp"
+
+#include "bdsg/hash_graph.hpp"
+
+#include <string>
+#include <set>
+#include <iostream>
+#include <algorithm>
+#include <vector>
+#include <utility>
+
+using namespace gfase;
+
+using ghc::filesystem::path;
+using bdsg::HashGraph;
+using handlegraph::handle_t;
+using handlegraph::nid_t;
+
+using std::sort;
+using std::string;
+using std::cerr;
+using std::endl;
+using std::set;
+using std::vector;
+using std::pair;
+
+void run_test(string& data_file,
+              const set<string>& phase_0_nodes,
+              const set<string>& phase_1_nodes,
+              set<vector<pair<string, bool>>>& correct_phase_paths) {
+    
+    path script_path = __FILE__;
+    path project_directory = script_path.parent_path().parent_path().parent_path();
+    path relative_gfa_path = data_file;
+    path absolute_gfa_path = project_directory / relative_gfa_path;
+    
+    GfaReader reader(absolute_gfa_path);
+    
+    HashGraph graph;
+    IncrementalIdMap<string> id_map;
+    
+    gfa_to_handle_graph(graph, id_map, absolute_gfa_path);
+    
+    MultiContactGraph contact_graph;
+    for (auto node_set : {make_pair(phase_0_nodes, true), make_pair(phase_1_nodes, false)}) {
+        for (auto node_name : node_set.first) {
+            int32_t node_id = id_map.get_id(node_name);
+            contact_graph.insert_node(node_id, node_set.second ? -1 : 1);
+        }
+    }
+    
+    set<vector<handle_t>> correct_phase_handle_paths;
+    for (const auto& phase_path : correct_phase_paths) {
+        vector<handle_t> phase_handle_path;
+        if (id_map.get_id(phase_path.front()) < id_map.get_id(phase_path.back())) {
+            for (auto it = phase_path.begin(); it != phase_path.end(); ++it) {
+                phase_handle_path.push_back(graph.get_handle(id_map.get_id(it->first), it->second));
+            }
+        }
+        else {
+            for (auto it = phase_path.rbegin(); it != phase_path.rend(); ++it) {
+                phase_handle_path.push_back(graph.get_handle(id_map.get_id(it->first), !it->second));
+            }
+        }
+        correct_phase_handle_paths.insert(phase_handle_path);
+    }
+    
+    set<vector<handle_t>> identified_phase_handle_paths;
+    graph.for_each_path_handle([&](const path_handle_t& path_handle) {
+        vector<handle_t> steps;
+        for (handle_t step : graph.scan_path(path_handle)) {
+            steps.push_back(step);
+        }
+        if (graph.get_id(steps.back()) < graph.get_id(steps.front())) {
+            vector<handle_t> rev_steps;
+            for (auto it = steps.rbegin(); it != steps.rend(); ++it) {
+                rev_steps.push_back(graph.flip(*it));
+            }
+            steps = rev_steps;
+        }
+        identified_phase_handle_paths.emplace(steps);
+    });
+    
+    if (identified_phase_handle_paths != correct_phase_handle_paths) {
+        throw runtime_error(("ERROR: incorrect phase paths detected in GFA " + data_file).c_str());
+    }
+}
+
+int main(){
+
+    {
+        string file = "data/simple_chain_long_haploid.gfa";
+        set<string> phase_0_nodes{"f", "d", "a"};
+        set<string> phase_1_nodes{"e", "c", "b"};
+        set<vector<pair<string, bool>>> correct_phase_paths{
+            {{"i", false}, {"a", false}, {"j", false}, {"d", false}, {"k", false}, {"f", false}, {"l", false}},
+            {{"i", false}, {"b", false}, {"j", false}, {"c", false}, {"k", false}, {"d", false}, {"l", false}}
+        };
+    }
+    
+    return 0;
+}

--- a/src/test/test_hamiltonian_chainer.cpp
+++ b/src/test/test_hamiltonian_chainer.cpp
@@ -36,7 +36,7 @@ void run_test(string& data_file,
               const set<string>& phase_0_nodes,
               const set<string>& phase_1_nodes,
               const set<pair<string, string>> alt_pairs,
-              const set<vector<pair<string, bool>>>& correct_phase_paths) {
+              const vector<vector<pair<string, bool>>>& correct_phase_paths) {
     
     path script_path = __FILE__;
     path project_directory = script_path.parent_path().parent_path().parent_path();
@@ -103,7 +103,7 @@ void run_test(string& data_file,
         contact_graph.set_partition(*alt_component.first.begin(), *partitions_first.begin());
     }
     
-    set<vector<handle_t>> correct_phase_handle_paths;
+    vector<vector<handle_t>> correct_phase_handle_paths;
     for (const auto& phase_path : correct_phase_paths) {
         vector<handle_t> phase_handle_path;
         if (id_map.get_id(phase_path.front().first) < id_map.get_id(phase_path.back().first)) {
@@ -116,13 +116,14 @@ void run_test(string& data_file,
                 phase_handle_path.push_back(graph.get_handle(id_map.get_id(it->first), !it->second));
             }
         }
-        correct_phase_handle_paths.insert(phase_handle_path);
+        correct_phase_handle_paths.push_back(phase_handle_path);
     }
+    sort(correct_phase_handle_paths.begin(), correct_phase_handle_paths.end());
     
     HamiltonianChainer chainer;
     chainer.generate_chain_paths(graph, contact_graph);
     
-    set<vector<handle_t>> identified_phase_handle_paths;
+    vector<vector<handle_t>> identified_phase_handle_paths;
     graph.for_each_path_handle([&](const path_handle_t& path_handle) {
         vector<handle_t> steps;
         for (handle_t step : graph.scan_path(path_handle)) {
@@ -135,8 +136,9 @@ void run_test(string& data_file,
             }
             steps = rev_steps;
         }
-        identified_phase_handle_paths.emplace(steps);
+        identified_phase_handle_paths.emplace_back(steps);
     });
+    sort(identified_phase_handle_paths.begin(), identified_phase_handle_paths.end());
     
     if (identified_phase_handle_paths != correct_phase_handle_paths) {
         for (bool correct : {true, false}) {
@@ -154,14 +156,100 @@ void run_test(string& data_file,
 
 int main(){
 
+//    {
+//        string file = "data/simple_chain_long_haploid.gfa";
+//        set<string> phase_0_nodes{"a", "d", "f"};
+//        set<string> phase_1_nodes{"b", "c", "e"};
+//        set<pair<string, string>> alt_pairs{{"a", "b"}, {"c", "d"}, {"e", "f"}};
+//        vector<vector<pair<string, bool>>> correct_phase_paths{
+//            {{"i", false}, {"a", false}, {"j", false}, {"d", false}, {"k", false}, {"f", false}, {"l", false}},
+//            {{"i", false}, {"b", false}, {"j", false}, {"c", false}, {"k", false}, {"e", false}, {"l", false}}
+//        };
+//        run_test(file, phase_0_nodes, phase_1_nodes, alt_pairs, correct_phase_paths);
+//    }
+//    {
+//        string file = "data/simple_chain_empty_node.gfa";
+//        set<string> phase_0_nodes{"a", "d", "f", "g"};
+//        set<string> phase_1_nodes{"b", "c", "e", "h"};
+//        set<pair<string, string>> alt_pairs{{"a", "b"}, {"c", "d"}, {"e", "f"}, {"g", "h"}};
+//        vector<vector<pair<string, bool>>> correct_phase_paths{
+//            {{"i", false}, {"a", false}, {"j", false}, {"d", false}, {"k", false}, {"f", false}, {"l", false}, {"g", false}, {"m", false}},
+//            {{"i", false}, {"b", false}, {"j", false}, {"c", false}, {"k", false}, {"e", false}, {"l", false}, {"h", false}, {"m", false}}
+//        };
+//        run_test(file, phase_0_nodes, phase_1_nodes, alt_pairs, correct_phase_paths);
+//    }
+//    {
+//        // induce a phase break by an unphased bubble
+//        string file = "data/simple_chain_empty_node.gfa";
+//        set<string> phase_0_nodes{"a", "d", "g"};
+//        set<string> phase_1_nodes{"b", "c", "h"};
+//        set<pair<string, string>> alt_pairs{{"a", "b"}, {"c", "d"}, {"g", "h"}};
+//        vector<vector<pair<string, bool>>> correct_phase_paths{
+//            {{"i", false}, {"a", false}, {"j", false}, {"d", false}, {"k", false}},
+//            {{"i", false}, {"b", false}, {"j", false}, {"c", false}, {"k", false}},
+//            {{"l", false}, {"g", false}, {"m", false}},
+//            {{"l", false}, {"h", false}, {"m", false}}
+//        };
+//        run_test(file, phase_0_nodes, phase_1_nodes, alt_pairs, correct_phase_paths);
+//    }
+//    {
+//        // include unphased, bridge-only components
+//        string file = "data/connected_components.gfa";
+//        set<string> phase_0_nodes{"b"};
+//        set<string> phase_1_nodes{"c"};
+//        set<pair<string, string>> alt_pairs{{"b", "c"}};
+//        vector<vector<pair<string, bool>>> correct_phase_paths{
+//            {{"a", false}, {"b", false}, {"d", false}},
+//            {{"a", false}, {"c", false}, {"d", false}}
+//        };
+//        run_test(file, phase_0_nodes, phase_1_nodes, alt_pairs, correct_phase_paths);
+//    }
     {
-        string file = "data/simple_chain_long_haploid.gfa";
-        set<string> phase_0_nodes{"a", "d", "f"};
-        set<string> phase_1_nodes{"b", "c", "e"};
-        set<pair<string, string>> alt_pairs{{"a", "b"}, {"c", "d"}, {"e", "f"}};
-        set<vector<pair<string, bool>>> correct_phase_paths{
-            {{"i", false}, {"a", false}, {"j", false}, {"d", false}, {"k", false}, {"f", false}, {"l", false}},
-            {{"i", false}, {"b", false}, {"j", false}, {"c", false}, {"k", false}, {"e", false}, {"l", false}}
+        string file = "data/big_test.gfa";
+        set<string> phase_0_nodes{
+            "b", "e",
+            "h", "n", "q", "s",
+            "tip_b", "tip_e",
+            "b3", "f3", "h3", "k3",
+            "a2", "b2", "f2", "h2",
+            "k2_0", "o2_0",
+            "k2_1", "o2_1"
+        };
+        set<string> phase_1_nodes{
+            "c", "f",
+            "i", "o", "r", "t",
+            "tip_c", "tip_f",
+            "c3", "e3", "i3", "l3",
+            "c2", "e2", "i2",
+            "l2_0", "p2_0",
+            "l2_1", "p2_1"
+        };
+        set<pair<string, string>> alt_pairs{
+            {"b", "c"}, {"e", "f"},
+            {"h", "i"}, {"n", "o"}, {"q", "r"}, {"s", "t"},
+            {"tip_b", "tip_c"}, {"tip_e", "tip_f"},
+            {"c3", "b3"}, {"f3", "e3"}, {"h3", "i3"}, {"k3", "l3"},
+            {"a2", "c2"}, {"b2", "c2"}, {"e2", "f2"}, {"h2", "i2"},
+            {"k2_0", "l2_0"}, {"o2_0", "p2_0"},
+            {"k2_1", "l2_1"}, {"o2_1", "p2_1"}
+        };
+        vector<vector<pair<string, bool>>> correct_phase_paths{
+            {{"a", false}, {"b", false}, {"d", false}, {"e", false}, {"g_a", false}},
+            {{"a", false}, {"c", false}, {"d", false}, {"f", false}, {"g_a", false}},
+            {{"g_b", false}, {"h", false}, {"j", false}},
+            {{"g_b", false}, {"i", false}, {"j", false}},
+            {{"m", false}, {"n", false}, {"p", false}, {"q", false}, {"s", false}},
+            {{"m", false}, {"o", false}, {"p", false}, {"r", false}, {"t", false}},
+            {{"tip_a", false}, {"tip_b", false}, {"tip_d", false}, {"tip_e", false}},
+            {{"tip_a", false}, {"tip_c", false}, {"tip_d", false}, {"tip_f", false}},
+            {{"a3", false}, {"b3", false}, {"d3", false}, {"f3", false}, {"g3", false}, {"h3", false}, {"j3", false}, {"k3", false}}, // TODO: this misses m3 because it's not a bridge...
+            {{"a3", false}, {"c3", false}, {"d3", false}, {"e3", false}, {"g3", false}, {"i3", false}, {"j3", false}, {"l3", false}},
+            {{"a2", false}, {"b2", false}, {"d2", false}, {"f2", false}, {"g2", false}, {"h2", false}, {"j2", false}, {"x2", false}},
+            {{"c2", false}, {"d2", false}, {"e2", false}, {"g2", false}, {"i2", false}, {"j2", false}, {"x2", false}},
+            {{"m2_0", false}, {"p2_0", false}, {"q2_0", false}}, // TODO: the current algorithm doesn't do well on [lk]_[01]
+            {{"m2_0", false}, {"o2_0", false}, {"q2_0", false}},
+            {{"m2_1", false}, {"p2_1", false}, {"q2_1", false}},
+            {{"m2_1", false}, {"o2_1", false}, {"q2_1", false}}
         };
         run_test(file, phase_0_nodes, phase_1_nodes, alt_pairs, correct_phase_paths);
     }

--- a/src/test/test_hamiltonian_chainer.cpp
+++ b/src/test/test_hamiltonian_chainer.cpp
@@ -121,7 +121,7 @@ void run_test(string& data_file,
     sort(correct_phase_handle_paths.begin(), correct_phase_handle_paths.end());
     
     HamiltonianChainer chainer;
-    chainer.generate_chain_paths(graph, contact_graph);
+    chainer.generate_chain_paths(graph, id_map, contact_graph);
     
     vector<vector<handle_t>> identified_phase_handle_paths;
     graph.for_each_path_handle([&](const path_handle_t& path_handle) {

--- a/src/test/test_hamiltonian_chainer.cpp
+++ b/src/test/test_hamiltonian_chainer.cpp
@@ -156,54 +156,54 @@ void run_test(string& data_file,
 
 int main(){
 
-//    {
-//        string file = "data/simple_chain_long_haploid.gfa";
-//        set<string> phase_0_nodes{"a", "d", "f"};
-//        set<string> phase_1_nodes{"b", "c", "e"};
-//        set<pair<string, string>> alt_pairs{{"a", "b"}, {"c", "d"}, {"e", "f"}};
-//        vector<vector<pair<string, bool>>> correct_phase_paths{
-//            {{"i", false}, {"a", false}, {"j", false}, {"d", false}, {"k", false}, {"f", false}, {"l", false}},
-//            {{"i", false}, {"b", false}, {"j", false}, {"c", false}, {"k", false}, {"e", false}, {"l", false}}
-//        };
-//        run_test(file, phase_0_nodes, phase_1_nodes, alt_pairs, correct_phase_paths);
-//    }
-//    {
-//        string file = "data/simple_chain_empty_node.gfa";
-//        set<string> phase_0_nodes{"a", "d", "f", "g"};
-//        set<string> phase_1_nodes{"b", "c", "e", "h"};
-//        set<pair<string, string>> alt_pairs{{"a", "b"}, {"c", "d"}, {"e", "f"}, {"g", "h"}};
-//        vector<vector<pair<string, bool>>> correct_phase_paths{
-//            {{"i", false}, {"a", false}, {"j", false}, {"d", false}, {"k", false}, {"f", false}, {"l", false}, {"g", false}, {"m", false}},
-//            {{"i", false}, {"b", false}, {"j", false}, {"c", false}, {"k", false}, {"e", false}, {"l", false}, {"h", false}, {"m", false}}
-//        };
-//        run_test(file, phase_0_nodes, phase_1_nodes, alt_pairs, correct_phase_paths);
-//    }
-//    {
-//        // induce a phase break by an unphased bubble
-//        string file = "data/simple_chain_empty_node.gfa";
-//        set<string> phase_0_nodes{"a", "d", "g"};
-//        set<string> phase_1_nodes{"b", "c", "h"};
-//        set<pair<string, string>> alt_pairs{{"a", "b"}, {"c", "d"}, {"g", "h"}};
-//        vector<vector<pair<string, bool>>> correct_phase_paths{
-//            {{"i", false}, {"a", false}, {"j", false}, {"d", false}, {"k", false}},
-//            {{"i", false}, {"b", false}, {"j", false}, {"c", false}, {"k", false}},
-//            {{"l", false}, {"g", false}, {"m", false}},
-//            {{"l", false}, {"h", false}, {"m", false}}
-//        };
-//        run_test(file, phase_0_nodes, phase_1_nodes, alt_pairs, correct_phase_paths);
-//    }
-//    {
-//        // include unphased, bridge-only components
-//        string file = "data/connected_components.gfa";
-//        set<string> phase_0_nodes{"b"};
-//        set<string> phase_1_nodes{"c"};
-//        set<pair<string, string>> alt_pairs{{"b", "c"}};
-//        vector<vector<pair<string, bool>>> correct_phase_paths{
-//            {{"a", false}, {"b", false}, {"d", false}},
-//            {{"a", false}, {"c", false}, {"d", false}}
-//        };
-//        run_test(file, phase_0_nodes, phase_1_nodes, alt_pairs, correct_phase_paths);
-//    }
+    {
+        string file = "data/simple_chain_long_haploid.gfa";
+        set<string> phase_0_nodes{"a", "d", "f"};
+        set<string> phase_1_nodes{"b", "c", "e"};
+        set<pair<string, string>> alt_pairs{{"a", "b"}, {"c", "d"}, {"e", "f"}};
+        vector<vector<pair<string, bool>>> correct_phase_paths{
+            {{"i", false}, {"a", false}, {"j", false}, {"d", false}, {"k", false}, {"f", false}, {"l", false}},
+            {{"i", false}, {"b", false}, {"j", false}, {"c", false}, {"k", false}, {"e", false}, {"l", false}}
+        };
+        run_test(file, phase_0_nodes, phase_1_nodes, alt_pairs, correct_phase_paths);
+    }
+    {
+        string file = "data/simple_chain_empty_node.gfa";
+        set<string> phase_0_nodes{"a", "d", "f", "g"};
+        set<string> phase_1_nodes{"b", "c", "e", "h"};
+        set<pair<string, string>> alt_pairs{{"a", "b"}, {"c", "d"}, {"e", "f"}, {"g", "h"}};
+        vector<vector<pair<string, bool>>> correct_phase_paths{
+            {{"i", false}, {"a", false}, {"j", false}, {"d", false}, {"k", false}, {"f", false}, {"l", false}, {"g", false}, {"m", false}},
+            {{"i", false}, {"b", false}, {"j", false}, {"c", false}, {"k", false}, {"e", false}, {"l", false}, {"h", false}, {"m", false}}
+        };
+        run_test(file, phase_0_nodes, phase_1_nodes, alt_pairs, correct_phase_paths);
+    }
+    {
+        // induce a phase break by an unphased bubble
+        string file = "data/simple_chain_empty_node.gfa";
+        set<string> phase_0_nodes{"a", "d", "g"};
+        set<string> phase_1_nodes{"b", "c", "h"};
+        set<pair<string, string>> alt_pairs{{"a", "b"}, {"c", "d"}, {"g", "h"}};
+        vector<vector<pair<string, bool>>> correct_phase_paths{
+            {{"i", false}, {"a", false}, {"j", false}, {"d", false}, {"k", false}},
+            {{"i", false}, {"b", false}, {"j", false}, {"c", false}, {"k", false}},
+            {{"l", false}, {"g", false}, {"m", false}},
+            {{"l", false}, {"h", false}, {"m", false}}
+        };
+        run_test(file, phase_0_nodes, phase_1_nodes, alt_pairs, correct_phase_paths);
+    }
+    {
+        // include unphased, bridge-only components
+        string file = "data/connected_components.gfa";
+        set<string> phase_0_nodes{"b"};
+        set<string> phase_1_nodes{"c"};
+        set<pair<string, string>> alt_pairs{{"b", "c"}};
+        vector<vector<pair<string, bool>>> correct_phase_paths{
+            {{"a", false}, {"b", false}, {"d", false}},
+            {{"a", false}, {"c", false}, {"d", false}}
+        };
+        run_test(file, phase_0_nodes, phase_1_nodes, alt_pairs, correct_phase_paths);
+    }
     {
         string file = "data/big_test.gfa";
         set<string> phase_0_nodes{
@@ -246,10 +246,75 @@ int main(){
             {{"a3", false}, {"c3", false}, {"d3", false}, {"e3", false}, {"g3", false}, {"i3", false}, {"j3", false}, {"l3", false}},
             {{"a2", false}, {"b2", false}, {"d2", false}, {"f2", false}, {"g2", false}, {"h2", false}, {"j2", false}, {"x2", false}},
             {{"c2", false}, {"d2", false}, {"e2", false}, {"g2", false}, {"i2", false}, {"j2", false}, {"x2", false}},
-            {{"m2_0", false}, {"p2_0", false}, {"q2_0", false}}, // TODO: the current algorithm doesn't do well on [lk]_[01]
-            {{"m2_0", false}, {"o2_0", false}, {"q2_0", false}},
-            {{"m2_1", false}, {"p2_1", false}, {"q2_1", false}},
-            {{"m2_1", false}, {"o2_1", false}, {"q2_1", false}}
+            {{"l2_0", false}, {"m2_0", false}, {"p2_0", false}, {"q2_0", false}},
+            {{"k2_0", false}, {"m2_0", false}, {"o2_0", false}, {"q2_0", false}},
+            {{"l2_1", false}, {"m2_1", false}, {"p2_1", false}, {"q2_1", false}},
+            {{"k2_1", false}, {"m2_1", false}, {"o2_1", false}, {"q2_1", false}}
+        };
+        run_test(file, phase_0_nodes, phase_1_nodes, alt_pairs, correct_phase_paths);
+    }
+    {
+        // TODO: the current algorithm can't really do anything with the triploid component, but
+        // maybe it could if we inserted a dummy node into non-star biclique adjacency components,
+        // which could then act as a bridge
+        string file = "data/chain_test.gfa";
+        set<string> phase_0_nodes{
+            "b", "e",
+            "tip_c", "tip_f",
+            "h", "k", "n", "q", "s",
+            "b2", "f2", "h2",
+            "k2_0", "o2_0",
+            "k2_1", "o2_1",
+            "b3", "f3", "h3", "k3",
+            "tree_c2", "tree_c0",
+            "c4", "f4", "i4", "k4"
+        };
+        set<string> phase_1_nodes{
+            "c", "f",
+            "tip_b", "tip_e",
+            "i", "l", "o", "r", "t",
+            "c2", "e2", "i2",
+            "l2_0", "p2_0",
+            "l2_1", "p2_1",
+            "c3", "e3", "i3", "l3",
+            "tree_c3", "tree_c1",
+            "b4", "e4", "h4", "l4"
+        };
+        set<pair<string, string>> alt_pairs{
+            {"b", "c"}, {"e", "f"},
+            {"tip_b", "tip_c"}, {"tip_e", "tip_f"},
+            {"h", "i"}, {"k", "l"}, {"n", "o"}, {"q", "r"}, {"s", "t"},
+            {"b2", "c2"}, {"e2", "f2"}, {"h2", "i2"},
+            {"k2_0", "l2_0"}, {"o2_0", "p2_0"},
+            {"k2_1", "l2_1"}, {"o2_1", "p2_1"},
+            {"c3", "b3"}, {"f3", "e3"}, {"h3", "i3"}, {"k3", "l3"},
+            {"tree_c2", "tree_c3"}, {"tree_c0", "tree_c1"},
+            {"c4", "b4"}, {"e4", "f4"}, {"h4", "i4"}, {"k4", "l4"}
+        };
+        vector<vector<pair<string, bool>>> correct_phase_paths{
+            {{"a", false}, {"b", false}, {"d", false}, {"e", false}, {"g_a", false}},
+            {{"a", false}, {"c", false}, {"d", false}, {"f", false}, {"g_a", false}},
+            {{"tip_a", false}, {"tip_b", false}, {"tip_d", false}, {"tip_e", false}},
+            {{"tip_a", false}, {"tip_c", false}, {"tip_d", false}, {"tip_f", false}},
+            {{"g_b", false}, {"h", false}, {"j", false}, {"k", false}, {"m", false}},
+            {{"n", false}, {"p", false}, {"q", false}, {"s", false}},
+            {{"g_b", false}, {"i", false}, {"j", false}, {"l", false}, {"m", false}, {"o", false}, {"p", false}, {"r", false}, {"t", false}},
+            {{"a2", false}, {"b2", false}, {"d2", false}, {"f2", false}},
+            {{"h2", false}, {"j2", false}, {"x2", false}},
+            {{"a2", false}, {"c2", false}, {"d2", false}, {"e2", false}},
+            {{"i2", false}, {"j2", false}, {"x2", false}},
+            {{"l2_0", false}, {"m2_0", false}, {"p2_0", false}, {"q2_0", false}},
+            {{"k2_0", false}, {"m2_0", false}, {"o2_0", false}, {"q2_0", false}},
+            {{"l2_1", false}, {"m2_1", false}, {"p2_1", false}, {"q2_1", false}},
+            {{"k2_1", false}, {"m2_1", false}, {"o2_1", false}, {"q2_1", false}},
+            {{"a3", false}, {"b3", false}, {"d3", false}, {"f3", false}, {"g3", false}, {"h3", false}, {"j3", false}, {"k3", false}},
+            {{"a3", false}, {"c3", false}, {"d3", false}, {"e3", false}, {"g3", false}, {"i3", false}, {"j3", false}, {"l3", false}},
+            {{"tree_b1", false}, {"tree_c3", false}, {"tree_d1", false}},
+            {{"tree_b1", false}, {"tree_c2", false}, {"tree_d1", false}},
+            {{"tree_b0", false}, {"tree_c0", false}, {"tree_d0", false}},
+            {{"tree_b0", false}, {"tree_c1", false}, {"tree_d0", false}},
+            {{"a4", false}, {"b4", false}, {"e4", true}, {"g4", false}, {"h4", false}, {"j4", true}, {"l4", false}},
+            {{"a4", false}, {"c4", false}, {"f4", false}, {"g4", false}, {"i4", true}, {"j4", true}, {"k4", false}}
         };
         run_test(file, phase_0_nodes, phase_1_nodes, alt_pairs, correct_phase_paths);
     }

--- a/src/test/test_hamiltonian_path.cpp
+++ b/src/test/test_hamiltonian_path.cpp
@@ -1,0 +1,30 @@
+#include "HamiltonianPath.hpp"
+#include "IncrementalIdMap.hpp"
+#include "gfa_to_handle.hpp"
+#include "handle_to_gfa.hpp"
+#include "graph_utility.hpp"
+#include "Filesystem.hpp"
+
+#include "bdsg/hash_graph.hpp"
+
+#include <string>
+#include <set>
+#include <iostream>
+#include <algorithm>
+
+using namespace gfase;
+
+using ghc::filesystem::path;
+using bdsg::HashGraph;
+using handlegraph::handle_t;
+
+using std::sort;
+using std::string;
+using std::cerr;
+using std::endl;
+
+int main(){
+
+    
+    return 0;
+}

--- a/src/test/test_hamiltonian_path.cpp
+++ b/src/test/test_hamiltonian_path.cpp
@@ -10,21 +10,227 @@
 #include <string>
 #include <set>
 #include <iostream>
+#include <unordered_set>
 #include <algorithm>
+#include <utility>
+#include <limits>
+#include <sstream>
 
 using namespace gfase;
 
 using ghc::filesystem::path;
 using bdsg::HashGraph;
+using bdsg::HandleGraph;
 using handlegraph::handle_t;
+using handlegraph::nid_t;
 
+using std::pair;
 using std::sort;
 using std::string;
 using std::cerr;
 using std::endl;
+using std::unordered_set;
+using std::numeric_limits;
+using std::stringstream;
+
+string path_to_string(const vector<handle_t>& path, const HandleGraph& graph,
+                      const IncrementalIdMap<string>& id_map) {
+    stringstream strm;
+    for (auto h : path) {
+        strm << "\t" << id_map.get_name(graph.get_id(h)) << (graph.get_is_reverse(h) ? "-" : "+") << endl;
+    }
+    return strm.str();
+}
+
+void run_test(string& data_file,
+              const unordered_set<pair<string, bool>>& starts,
+              const unordered_set<pair<string, bool>>& ends,
+              const unordered_set<string>& targets,
+              const unordered_set<string>& prohibited,
+              bool should_complete,
+              size_t minimum_hamiltonian_length,
+              size_t unique_prefix_len,
+              size_t max_iters = numeric_limits<size_t>::max()) {
+    
+    path script_path = __FILE__;
+    path project_directory = script_path.parent_path().parent_path().parent_path();
+    path relative_gfa_path = data_file;
+    path absolute_gfa_path = project_directory / relative_gfa_path;
+    
+    GfaReader reader(absolute_gfa_path);
+    
+    HashGraph graph;
+    IncrementalIdMap<string> id_map;
+    
+    gfa_to_handle_graph(graph, id_map, absolute_gfa_path);
+    
+    unordered_set<nid_t> target_nodes, prohibited_nodes;
+    for (auto target : targets) {
+        target_nodes.insert(id_map.get_id(target));
+    }
+    for (auto antitarget : prohibited) {
+        prohibited_nodes.insert(id_map.get_id(antitarget));
+    }
+    unordered_set<handle_t> allowed_starts, allowed_ends;
+    for (auto start : starts) {
+        allowed_starts.insert(graph.get_handle(id_map.get_id(start.first), start.second));
+    }
+    for (auto end : ends) {
+        allowed_ends.insert(graph.get_handle(id_map.get_id(end.first), end.second));
+    }
+    
+    auto result = find_hamiltonian_path(graph, target_nodes, prohibited_nodes,
+                                        allowed_starts, allowed_ends, max_iters);
+    
+    if (!should_complete) {
+        if (result.is_solved) {
+            stringstream strm;
+            strm << "ERROR: Hamiltonian path algorithm exited successfully when it should fail on GFA " << data_file << endl;
+            strm << "Hamiltonian path identified:" << endl;
+            strm << path_to_string(result.hamiltonian_path, graph, id_map);
+            throw runtime_error(strm.str());
+        }
+    }
+    else {
+        if (!result.is_solved) {
+            stringstream strm;
+            strm << "ERROR: Hamiltonian path algorithm failed when it should fail on GFA " << data_file << endl;
+            throw runtime_error(strm.str());
+        }
+        else {
+            if (!targets.empty()) {
+                const auto& path = result.hamiltonian_path;
+                const auto& prefix = result.unique_prefix;
+                
+                if (path.empty()) {
+                    stringstream strm;
+                    strm << "ERROR: Empty path found despite specifying target nodes on GFA " << data_file << endl;
+                    throw runtime_error(strm.str());
+                }
+                
+                if (!starts.empty()) {
+                    pair<string, bool> start(id_map.get_name(graph.get_id(path.front())),
+                                             graph.get_is_reverse(path.front()));
+                    if (!starts.count(start)) {
+                        stringstream strm;
+                        strm << "ERROR: Hamiltonian path algorithm does not start at an allowed start on GFA " << data_file << endl;
+                        strm << "Hamiltonian path identified:" << endl;
+                        strm << path_to_string(path, graph, id_map);
+                        throw runtime_error(strm.str());
+                    }
+                }
+                if (!ends.empty()) {
+                    pair<string, bool> end(id_map.get_name(graph.get_id(path.back())),
+                                           graph.get_is_reverse(path.back()));
+                    if (!ends.count(end)) {
+                        stringstream strm;
+                        strm << "ERROR: Hamiltonian path algorithm does not end at an allowed end on GFA " << data_file << endl;
+                        strm << "Hamiltonian path identified:" << endl;
+                        strm << path_to_string(path, graph, id_map);
+                        throw runtime_error(strm.str());
+                    }
+                }
+                
+                unordered_set<nid_t> path_ids;
+                for (size_t i = 0; i < path.size(); ++i) {
+                    auto nid = graph.get_id(path[i]);
+                    if (prohibited_nodes.count(nid)) {
+                        stringstream strm;
+                        strm << "ERROR: Hamiltonian path contains prohibited node " << id_map.get_name(graph.get_id(path[i])) << " on GFA " << data_file << endl;
+                        strm << "Hamiltonian path:" << endl;
+                        strm << path_to_string(path, graph, id_map);
+                        throw runtime_error(strm.str());
+                    }
+                    if (path_ids.count(nid)) {
+                        stringstream strm;
+                        strm << "ERROR: Hamiltonian path contains a repeated node " << id_map.get_name(nid) << " on GFA " << data_file << endl;
+                        strm << "Hamiltonian path:" << endl;
+                        strm << path_to_string(path, graph, id_map);
+                        throw runtime_error(strm.str());
+                    }
+                    path_ids.insert(nid);
+                    if (i > 0) {
+                        if (!graph.has_edge(path[i - 1], path[i])) {
+                            stringstream strm;
+                            strm << "ERROR: Hamiltonian path contains an invalid edge between indexes " << (i - 1) << " and " << i << " on GFA " << data_file << endl;
+                            strm << "Hamiltonian path:" << endl;
+                            strm << path_to_string(path, graph, id_map);
+                            throw runtime_error(strm.str());
+                        }
+                    }
+                }
+                for (auto target_name : targets) {
+                    if (!path_ids.count(id_map.get_id(target_name))) {
+                        stringstream strm;
+                        strm << "ERROR: Hamiltonian path is missing target node " << target_name << " on GFA " << data_file << endl;
+                        strm << "Hamiltonian path:" << endl;
+                        strm << path_to_string(path, graph, id_map);
+                        throw runtime_error(strm.str());
+                    }
+                }
+                
+                if (path.size() != minimum_hamiltonian_length) {
+                    stringstream strm;
+                    strm << "ERROR: Hamiltonian is length " << path.size() << " when " << minimum_hamiltonian_length << " was expected on GFA " << data_file << endl;
+                    strm << "Hamiltonian path:" << endl;
+                    strm << path_to_string(path, graph, id_map);
+                    throw runtime_error(strm.str());
+                }
+                
+                if (prefix.size() != unique_prefix_len) {
+                    stringstream strm;
+                    strm << "ERROR: Unique prefix is length " << prefix.size() << " when " << unique_prefix_len << " was expected on GFA " << data_file << endl;
+                    strm << "Hamiltonian path:" << endl;
+                    strm << path_to_string(path, graph, id_map);
+                    strm << "Unique prefix:" << endl;
+                    strm << path_to_string(prefix, graph, id_map);
+                    throw runtime_error(strm.str());
+                }
+                for (size_t i = 0; i < prefix.size(); ++i) {
+                    if (prefix[i] != path[i]) {
+                        stringstream strm;
+                        strm << "ERROR: Unique prefix does not match full path on GFA " << data_file << endl;
+                        strm << "Hamiltonian path:" << endl;
+                        strm << path_to_string(path, graph, id_map);
+                        strm << "Unique prefix:" << endl;
+                        strm << path_to_string(prefix, graph, id_map);
+                        throw runtime_error(strm.str());
+                    }
+                }
+                
+                // TODO: checking the uniqueness of the prefix is actually pretty hard...
+            }
+            else {
+                if (!result.hamiltonian_path.empty()) {
+                    stringstream strm;
+                    strm << "ERROR: Non-empty path found despite specifying no target nodes on GFA " << data_file << endl;
+                    throw runtime_error(strm.str());
+                }
+            }
+        }
+    }
+}
 
 int main(){
-
+    
+    {
+        string data_file = "data/simple_chain.gfa";
+        
+        unordered_set<pair<string, bool>> starts{
+            pair<string, bool>("i", false)
+        };
+        unordered_set<pair<string, bool>> ends{
+            pair<string, bool>("m", false)
+        };
+        unordered_set<string> target_nodes{"a", "d", "e", "h"};
+        unordered_set<string> prohibited_nodes{};
+        bool should_complete = true;
+        size_t minimum_hamiltonian_length = 9;
+        size_t unique_prefix_len = 9;
+        
+        run_test(data_file, starts, ends, target_nodes, prohibited_nodes,
+                 should_complete, minimum_hamiltonian_length, unique_prefix_len);
+    }
     
     return 0;
 }


### PR DESCRIPTION
This PR includes all of the machinery to hook in a new chaining algorithm that can handle bridge components as well as simple bubbles, which should make it work better in graphs with more complex local structure (like the ones generated by verkko). It's all unit tested, but I haven't done any work to benchmark it on real data. It's also not yet exposed at the command line for `phase_contacts_with_monte_carlo`, but the machinery is all there to switch off between the new and old chainers.

Edit: I have now added a CLI option as well.