### PR TITLE
Incorporate basic overlap awareness in the unzipping process

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -451,6 +451,7 @@ set(TESTS
         test_htslib_bam_reader
         test_incremental_id_io
         test_kmer_unordered_set
+	test_overlaps
         test_phase_haplotype_paths
         test_minimap2
         test_minimap2_no_io

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ set(SOURCES
         src/MurmurHash3.cpp
         src/MultiContactGraph.cpp
         src/optimize.cpp
+	src/Overlaps.cpp
         src/VectorMultiContactGraph.cpp
         ##        src/OverlapMap.cpp
         src/Phase.cpp

--- a/inc/Overlaps.hpp
+++ b/inc/Overlaps.hpp
@@ -67,6 +67,8 @@ public:
     // and with query/ref roles swapped
     Cigar reverse() const;
     
+    // true if there are no CIGAR operations with length > 0
+    bool empty() const;
     // number of operations
     size_t size() const;
     // i-th operation
@@ -92,7 +94,7 @@ public:
     Overlaps() = default;
     ~Overlaps() = default;
     
-    
+    // record an overlap, ignores "*" and "0M" alignments
     void record_overlap(handle_t a, handle_t b, const string& cigar);
     
     // true if there are no overlaps recorded

--- a/inc/Overlaps.hpp
+++ b/inc/Overlaps.hpp
@@ -32,6 +32,8 @@ public:
     
     char type() const;
     uint32_t length() const;
+    uint32_t ref_length() const;
+    uint32_t query_length() const;
     
 private:
     
@@ -56,16 +58,18 @@ private:
 class Cigar {
 public:
     // parse a CIGAR string
-    Cigar(const std::string& cigar_string);
+    Cigar(const string& cigar_string);
     Cigar() = default;
     ~Cigar() = default;
     
     // get the CIGAR string for this alignment
-    std::string get_string() const;
+    string get_string() const;
     
     // return the CIGAR string for the same alignment, but reversed
     // and with query/ref roles swapped
     Cigar reverse() const;
+    // the length in the ref and query, in that order
+    pair<size_t, size_t> aligned_length() const;
     
     // true if there are no CIGAR operations with length > 0
     bool empty() const;
@@ -90,25 +94,27 @@ private:
  */
 class Overlaps {
 public:
-    Overlaps(const HandleGraph& graph);
     Overlaps() = default;
     ~Overlaps() = default;
     
     // record an overlap, ignores "*" and "0M" alignments
-    void record_overlap(handle_t a, handle_t b, const string& cigar);
+    void record_overlap(const HandleGraph& graph, handle_t a, handle_t b, const string& cigar);
+    // record an overlap from an already-parsed CIGAR string
+    void record_overlap(const HandleGraph& graph, handle_t a, handle_t b, const Cigar& cigar);
+    // remove an overlap if one exists (otherwise do nothing)
+    void remove_overlap(const HandleGraph& graph, handle_t a, handle_t b);
     
     // true if there are no overlaps recorded
     bool is_blunt() const;
     
     // true if there is an edge from a to b with an overlap
-    bool has_overlap(handle_t a, handle_t b) const;
+    bool has_overlap(const HandleGraph& graph, handle_t a, handle_t b) const;
     
     // get the (oriented) overlap of a onto b
-    Cigar get_overlap(handle_t a, handle_t b) const;
+    Cigar get_overlap(const HandleGraph& graph, handle_t a, handle_t b) const;
     
 private:
     
-    const HandleGraph* graph;
     unordered_map<edge_t, Cigar> overlaps;
 };
 

--- a/inc/Overlaps.hpp
+++ b/inc/Overlaps.hpp
@@ -1,0 +1,114 @@
+#ifndef GFASE_OVERLAPS_HPP
+#define GFASE_OVERLAPS_HPP
+
+#include "bdsg/hash_graph.hpp"
+#include <unordered_map>
+#include <string>
+#include <vector>
+#include <cstdint>
+#include <array>
+
+
+using handlegraph::handle_t;
+using handlegraph::edge_t;
+using std::unordered_map;
+using bdsg::HandleGraph;
+using std::string;
+using std::vector;
+using std::array;
+using std::pair;
+
+
+class Cigar; // forward declaration
+
+/*
+ * Single operation in a CIGAR string
+ */
+class CigarOperation{
+public:
+    CigarOperation(uint32_t length, char type);
+    CigarOperation() = default;
+    ~CigarOperation() = default;
+    
+    char type() const;
+    uint32_t length() const;
+    
+private:
+    
+    // Map from all possible cigar chars to 0-8
+    static const array<uint8_t,128> cigar_code;
+    
+    // Map back to the human readable characters
+    static const array<char,9> cigar_type;
+    
+    // Check if a cigar operation consumes a base in the reference or query
+    static const array<bool,9> is_ref_move;
+    static const array<bool,9> is_query_move;
+    
+    /// Attributes ///
+    uint8_t code;
+    uint32_t op_length;
+};
+
+/*
+ * A parsed CIGAR string
+ */
+class Cigar {
+public:
+    // parse a CIGAR string
+    Cigar(const std::string& cigar_string);
+    Cigar() = default;
+    ~Cigar() = default;
+    
+    // get the CIGAR string for this alignment
+    std::string get_string() const;
+    
+    // return the CIGAR string for the same alignment, but reversed
+    // and with query/ref roles swapped
+    Cigar reverse() const;
+    
+    // number of operations
+    size_t size() const;
+    // i-th operation
+    const CigarOperation& at(size_t i) const;
+    
+    // foreach interface
+    using iterator = std::vector<CigarOperation>::const_iterator;
+    iterator begin() const;
+    iterator end() const;
+    
+private:
+    
+    std::vector<CigarOperation> operations;
+    
+};
+
+/*
+ * Records overlaps between nodes of a graph
+ */
+class Overlaps {
+public:
+    Overlaps(const HandleGraph& graph);
+    Overlaps() = default;
+    ~Overlaps() = default;
+    
+    
+    void record_overlap(handle_t a, handle_t b, const string& cigar);
+    
+    // true if there are no overlaps recorded
+    bool is_blunt() const;
+    
+    // true if there is an edge from a to b with an overlap
+    bool has_overlap(handle_t a, handle_t b) const;
+    
+    // get the (oriented) overlap of a onto b
+    Cigar get_overlap(handle_t a, handle_t b) const;
+    
+private:
+    
+    const HandleGraph* graph;
+    unordered_map<edge_t, Cigar> overlaps;
+};
+
+
+#endif //GFASE_OVERLAPS_HPP

--- a/inc/Overlaps.hpp
+++ b/inc/Overlaps.hpp
@@ -110,7 +110,8 @@ public:
     // true if there is an edge from a to b with an overlap
     bool has_overlap(const HandleGraph& graph, handle_t a, handle_t b) const;
     
-    // get the (oriented) overlap of a onto b
+    // get the (oriented) overlap of a onto b. if no overlap has been
+    // recorded, then returns an empty CIGAR
     Cigar get_overlap(const HandleGraph& graph, handle_t a, handle_t b) const;
     
 private:

--- a/inc/Phase.hpp
+++ b/inc/Phase.hpp
@@ -265,10 +265,10 @@ void phase(path gfa_path, size_t k, path paternal_kmers, path maternal_kmers, pa
 
         string filename_prefix = output_directory / "components" / ("component_" + to_string(c) + "_");
         ofstream file(filename_prefix + ".gfa");
-        handle_graph_to_gfa(connected_components[c], connected_component_ids[c], file);
+        handle_graph_to_gfa(cc_graph, cc_id_map, cc_overlaps, file);
 
         ofstream test_gfa_meta(filename_prefix + "ploidy_metagraph.gfa");
-        handle_graph_to_gfa(ploidy_bipartition.metagraph, test_gfa_meta);
+        handle_graph_to_gfa(ploidy_bipartition.metagraph, test_gfa_meta, Overlaps());
 
         ofstream test_csv_meta_ploidy(filename_prefix + "ploidy_metagraph.csv");
         ploidy_bipartition.write_meta_graph_csv(test_csv_meta_ploidy);
@@ -277,7 +277,7 @@ void phase(path gfa_path, size_t k, path paternal_kmers, path maternal_kmers, pa
         ploidy_bipartition.write_parent_graph_csv(test_csv_parent_ploidy);
 
         ofstream test_gfa_chain(filename_prefix + "chain_metagraph.gfa");
-        handle_graph_to_gfa(chain_bipartition.metagraph, test_gfa_chain);
+        handle_graph_to_gfa(chain_bipartition.metagraph, test_gfa_chain, Overlaps());
 
         ofstream test_csv_meta_chain(filename_prefix + "chain_metagraph.csv");
         chain_bipartition.write_meta_graph_csv(test_csv_meta_chain);
@@ -291,7 +291,7 @@ void phase(path gfa_path, size_t k, path paternal_kmers, path maternal_kmers, pa
         merge_diploid_singletons(diploid_path_names, chain_bipartition);
 
         ofstream test_gfa_chain_merged(filename_prefix + "chain_metagraph_merged.gfa");
-        handle_graph_to_gfa(chain_bipartition.metagraph, test_gfa_chain_merged);
+        handle_graph_to_gfa(chain_bipartition.metagraph, test_gfa_chain_merged, Overlaps());
 
         ofstream test_csv_meta_chain_merged(filename_prefix + "chain_metagraph_merged.csv");
         chain_bipartition.write_meta_graph_csv(test_csv_meta_chain_merged);
@@ -361,7 +361,7 @@ void phase(path gfa_path, size_t k, path paternal_kmers, path maternal_kmers, pa
         write_paths_to_csv(cc_graph, cc_id_map, provenance_csv_file);
 
         ofstream test_gfa_phased(output_directory / (filename_prefix + "phased.gfa"));
-        handle_graph_to_gfa(cc_graph, cc_id_map, test_gfa_phased);
+        handle_graph_to_gfa(cc_graph, cc_id_map, cc_overlaps, test_gfa_phased);
 
         cc_graph.for_each_handle([&](const handle_t& h){
             auto id = cc_graph.get_id(h);

--- a/inc/Phase.hpp
+++ b/inc/Phase.hpp
@@ -242,10 +242,12 @@ void phase(path gfa_path, size_t k, path paternal_kmers, path maternal_kmers, pa
     vector <vector <handle_t> > unphased_handles_per_component(connected_components.size());
 
     for (size_t c=0; c<connected_components.size(); c++){
-        unzip(connected_components[c], connected_component_ids[c], false);
-
+        
         auto& cc_graph = connected_components[c];
         auto& cc_id_map = connected_component_ids[c];
+        auto& cc_overlaps = connected_component_overlaps[c];
+        
+        unzip(cc_graph, cc_id_map, cc_overlaps, false);
 
         // Generate criteria for diploid node BFS
         unordered_set<nid_t> diploid_nodes;
@@ -355,7 +357,7 @@ void phase(path gfa_path, size_t k, path paternal_kmers, path maternal_kmers, pa
             prev_subgraph_index = subgraph_index;
         });
 
-        unzip(cc_graph, cc_id_map, false);
+        unzip(cc_graph, cc_id_map, cc_overlaps, false);
         write_paths_to_csv(cc_graph, cc_id_map, provenance_csv_file);
 
         ofstream test_gfa_phased(output_directory / (filename_prefix + "phased.gfa"));

--- a/inc/Phase.hpp
+++ b/inc/Phase.hpp
@@ -164,7 +164,7 @@ void phase(path gfa_path, size_t k, path paternal_kmers, path maternal_kmers, pa
 
     HashGraph graph;
     IncrementalIdMap<string> id_map;
-    Overlaps overlaps(graph);
+    Overlaps overlaps;
     KmerSets <FixedBinarySequence <T, T2> > ks(paternal_kmers, maternal_kmers);
 
     if (ks.get_k() != k){
@@ -217,10 +217,11 @@ void phase(path gfa_path, size_t k, path paternal_kmers, path maternal_kmers, pa
 
     vector<HashGraph> connected_components;
     vector <IncrementalIdMap<string> > connected_component_ids;
+    vector<Overlaps> connected_component_overlaps;
 
     cerr << "Finding connected components..." << '\n';
 
-    split_connected_components(graph, id_map, connected_components, connected_component_ids, true);
+    split_connected_components(graph, id_map, overlaps, connected_components, connected_component_ids, connected_component_overlaps, true);
 
     cerr << "Unzipping..." << '\n';
 

--- a/inc/Phase.hpp
+++ b/inc/Phase.hpp
@@ -268,7 +268,7 @@ void phase(path gfa_path, size_t k, path paternal_kmers, path maternal_kmers, pa
         handle_graph_to_gfa(cc_graph, cc_id_map, cc_overlaps, file);
 
         ofstream test_gfa_meta(filename_prefix + "ploidy_metagraph.gfa");
-        handle_graph_to_gfa(ploidy_bipartition.metagraph, test_gfa_meta, Overlaps());
+        handle_graph_to_gfa(ploidy_bipartition.metagraph, test_gfa_meta);
 
         ofstream test_csv_meta_ploidy(filename_prefix + "ploidy_metagraph.csv");
         ploidy_bipartition.write_meta_graph_csv(test_csv_meta_ploidy);
@@ -277,7 +277,7 @@ void phase(path gfa_path, size_t k, path paternal_kmers, path maternal_kmers, pa
         ploidy_bipartition.write_parent_graph_csv(test_csv_parent_ploidy);
 
         ofstream test_gfa_chain(filename_prefix + "chain_metagraph.gfa");
-        handle_graph_to_gfa(chain_bipartition.metagraph, test_gfa_chain, Overlaps());
+        handle_graph_to_gfa(chain_bipartition.metagraph, test_gfa_chain);
 
         ofstream test_csv_meta_chain(filename_prefix + "chain_metagraph.csv");
         chain_bipartition.write_meta_graph_csv(test_csv_meta_chain);
@@ -291,7 +291,7 @@ void phase(path gfa_path, size_t k, path paternal_kmers, path maternal_kmers, pa
         merge_diploid_singletons(diploid_path_names, chain_bipartition);
 
         ofstream test_gfa_chain_merged(filename_prefix + "chain_metagraph_merged.gfa");
-        handle_graph_to_gfa(chain_bipartition.metagraph, test_gfa_chain_merged, Overlaps());
+        handle_graph_to_gfa(chain_bipartition.metagraph, test_gfa_chain_merged);
 
         ofstream test_csv_meta_chain_merged(filename_prefix + "chain_metagraph_merged.csv");
         chain_bipartition.write_meta_graph_csv(test_csv_meta_chain_merged);

--- a/inc/Phase.hpp
+++ b/inc/Phase.hpp
@@ -164,6 +164,7 @@ void phase(path gfa_path, size_t k, path paternal_kmers, path maternal_kmers, pa
 
     HashGraph graph;
     IncrementalIdMap<string> id_map;
+    Overlaps overlaps(graph);
     KmerSets <FixedBinarySequence <T, T2> > ks(paternal_kmers, maternal_kmers);
 
     if (ks.get_k() != k){
@@ -172,7 +173,7 @@ void phase(path gfa_path, size_t k, path paternal_kmers, path maternal_kmers, pa
 
     cerr << "Loading GFA..." << '\n';
 
-    gfa_to_handle_graph(graph, id_map, gfa_path, false);
+    gfa_to_handle_graph(graph, id_map, overlaps, gfa_path, false);
 
     cerr << "\tNumber of components in graph: " << graph.get_path_count() << '\n';
 

--- a/inc/chain.hpp
+++ b/inc/chain.hpp
@@ -100,6 +100,7 @@ void write_chaining_info_to_file(
 void chain_phased_gfa(
         MutablePathDeletableHandleGraph& graph,
         IncrementalIdMap<string>& id_map,
+        Overlaps& overlaps,
         const BubbleGraph& bubble_graph,
         path output_dir,
         bool write_gfa = true,

--- a/inc/gfa_to_handle.hpp
+++ b/inc/gfa_to_handle.hpp
@@ -10,6 +10,7 @@
 #include "bdsg/hash_graph.hpp"
 #include "handlegraph/handle_graph.hpp"
 #include "IncrementalIdMap.hpp"
+#include "Overlaps.hpp"
 #include "GfaReader.hpp"
 
 #include <cctype>
@@ -31,6 +32,7 @@ nid_t parse_gfa_sequence_id(const string& s, IncrementalIdMap<string>& id_map);
 void gfa_to_handle_graph(
         MutablePathMutableHandleGraph& graph,
         IncrementalIdMap<string>& id_map,
+        Overlaps& overlaps,
         path gfa_file_path,
         bool ignore_singleton_paths=true,
         bool ignore_paths=false

--- a/inc/graph_utility.hpp
+++ b/inc/graph_utility.hpp
@@ -111,6 +111,7 @@ void split_connected_components(
 void write_connected_components_to_gfas(
         const MutablePathDeletableHandleGraph& graph,
         const IncrementalIdMap<string>& id_map,
+        const Overlaps& overlaps,
         path output_directory);
 
 void run_command(string& argument_string);

--- a/inc/graph_utility.hpp
+++ b/inc/graph_utility.hpp
@@ -145,7 +145,7 @@ void un_extend_paths(
         const vector <pair<path_handle_t, handle_t> >& to_be_prepended,
         const vector <pair<path_handle_t, handle_t> >& to_be_appended);
 
-void unzip(MutablePathDeletableHandleGraph& graph, IncrementalIdMap<string>& id_map, const Overlaps& overlaps, bool keep_paths=false, bool delete_islands=true);
+void unzip(MutablePathDeletableHandleGraph& graph, IncrementalIdMap<string>& id_map, Overlaps& overlaps, bool keep_paths=false, bool delete_islands=true);
 
 void for_each_tip(const HandleGraph& graph, const function<void(const handle_t& h, bool is_left, bool is_right)>& f);
 

--- a/inc/graph_utility.hpp
+++ b/inc/graph_utility.hpp
@@ -2,12 +2,13 @@
 #define GFASE_GRAPH_UTILITY_HPP
 
 #include "IncrementalIdMap.hpp"
+#include "SubgraphOverlay.hpp"
 #include "gfa_to_handle.hpp"
 #include "handle_to_gfa.hpp"
 #include "Filesystem.hpp"
 #include "GfaReader.hpp"
+#include "Overlaps.hpp"
 #include "CLI11.hpp"
-#include "SubgraphOverlay.hpp"
 
 #include "bdsg/hash_graph.hpp"
 
@@ -83,15 +84,19 @@ void for_each_connected_component_subgraph(HandleGraph& graph, const function<vo
 void split_connected_components(
         MutablePathDeletableHandleGraph& graph,
         IncrementalIdMap<string>& id_map,
+        Overlaps& overlaps,
         vector<HashGraph>& graphs,
         vector<IncrementalIdMap<string> >& id_maps,
+        vector<Overlaps>& comp_overlaps,
         bool delete_visited_components = false);
 
 void split_connected_components(
         MutablePathDeletableHandleGraph& graph,
         IncrementalIdMap<string>& id_map,
+        Overlaps& overlaps,
         vector<HashGraph>& graphs,
         vector<IncrementalIdMap<string> >& id_maps,
+        vector<Overlaps>& comp_overlaps,
         vector <vector <pair <string, string> > >& in_edges,
         vector <vector <pair <string, string> > >& out_edges,
         const unordered_set<nid_t>& do_not_visit,
@@ -140,7 +145,7 @@ void un_extend_paths(
         const vector <pair<path_handle_t, handle_t> >& to_be_prepended,
         const vector <pair<path_handle_t, handle_t> >& to_be_appended);
 
-void unzip(MutablePathDeletableHandleGraph& graph, IncrementalIdMap<string>& id_map, bool keep_paths=false, bool delete_islands=true);
+void unzip(MutablePathDeletableHandleGraph& graph, IncrementalIdMap<string>& id_map, const Overlaps& overlaps, bool keep_paths=false, bool delete_islands=true);
 
 void for_each_tip(const HandleGraph& graph, const function<void(const handle_t& h, bool is_left, bool is_right)>& f);
 

--- a/inc/handle_to_gfa.hpp
+++ b/inc/handle_to_gfa.hpp
@@ -36,7 +36,7 @@ void write_path_to_gfa(
         const path_handle_t& path,
         ostream& output_file);
 
-void handle_graph_to_gfa(const HandleGraph& graph, const Overlaps& overlaps, ostream& output_gfa);
+void handle_graph_to_gfa(const HandleGraph& graph, ostream& output_gfa);
 
 void handle_graph_to_gfa(const PathHandleGraph& graph, const IncrementalIdMap<string>& id_map, const Overlaps& overlaps, ostream& output_gfa);
 

--- a/inc/handle_to_gfa.hpp
+++ b/inc/handle_to_gfa.hpp
@@ -4,6 +4,7 @@
 #include "handlegraph/path_handle_graph.hpp"
 #include "handlegraph/handle_graph.hpp"
 #include "IncrementalIdMap.hpp"
+#include "Overlaps.hpp"
 #include <fstream>
 
 using handlegraph::PathHandleGraph;
@@ -25,9 +26,9 @@ void write_node_to_gfa(const HandleGraph& graph, const handle_t& node, ostream& 
 
 void write_node_to_gfa(const HandleGraph& graph, const IncrementalIdMap<string>& id_map, const handle_t& node, ostream& output_file);
 
-void write_edge_to_gfa(const HandleGraph& graph, const edge_t& edge, ostream& output_file);
+void write_edge_to_gfa(const HandleGraph& graph, const Overlaps& overlaps, const edge_t& edge, ostream& output_file);
 
-void write_edge_to_gfa(const HandleGraph& graph, const IncrementalIdMap<string>& id_map, const edge_t& edge, ostream& output_file);
+void write_edge_to_gfa(const HandleGraph& graph, const IncrementalIdMap<string>& id_map, const Overlaps& overlaps, const edge_t& edge, ostream& output_file);
 
 void write_path_to_gfa(
         const PathHandleGraph& graph,
@@ -35,9 +36,9 @@ void write_path_to_gfa(
         const path_handle_t& path,
         ostream& output_file);
 
-void handle_graph_to_gfa(const HandleGraph& graph, ostream& output_gfa);
+void handle_graph_to_gfa(const HandleGraph& graph, const Overlaps& overlaps, ostream& output_gfa);
 
-void handle_graph_to_gfa(const PathHandleGraph& graph, const IncrementalIdMap<string>& id_map, ostream& output_gfa);
+void handle_graph_to_gfa(const PathHandleGraph& graph, const IncrementalIdMap<string>& id_map, const Overlaps& overlaps, ostream& output_gfa);
 
 }
 

--- a/src/Overlaps.cpp
+++ b/src/Overlaps.cpp
@@ -191,6 +191,11 @@ bool Overlaps::has_overlap(const HandleGraph& graph, handle_t a, handle_t b) con
     return overlaps.count(graph.edge_handle(a, b));
 }
 
+bool Overlaps::is_blunt() const {
+    return overlaps.empty();
+}
+
+
 Cigar Overlaps::get_overlap(const HandleGraph& graph, handle_t a, handle_t b) const {
     Cigar cigar;
     auto it = overlaps.find(graph.edge_handle(a, b));

--- a/src/Overlaps.cpp
+++ b/src/Overlaps.cpp
@@ -114,6 +114,10 @@ string Cigar::get_string() const {
         s += c.type();
     }
     
+    if (s.empty()) {
+        s = "0M";
+    }
+    
     return s;
 }
 

--- a/src/Overlaps.cpp
+++ b/src/Overlaps.cpp
@@ -6,6 +6,7 @@
 using std::to_string;
 using std::make_pair;
 using std::runtime_error;
+using std::move;
 
 ///
 /// M   I   D   N   S   H   P   =   X
@@ -119,6 +120,10 @@ Cigar Cigar::reverse() const {
     return reversed;
 }
 
+bool Cigar::empty() const {
+    return operations.empty();
+}
+
 size_t Cigar::size() const {
     return operations.size();
 }
@@ -140,7 +145,10 @@ Overlaps::Overlaps(const HandleGraph& graph) : graph(&graph) {
 }
 
 void Overlaps::record_overlap(handle_t a, handle_t b, const string& cigar) {
-    overlaps[graph->edge_handle(a, b)] = Cigar(cigar);
+    Cigar parsed(cigar);
+    if (!parsed.empty()) {
+        overlaps[graph->edge_handle(a, b)] = move(parsed);
+    }
 }
 
 bool Overlaps::has_overlap(handle_t a, handle_t b) const {

--- a/src/Overlaps.cpp
+++ b/src/Overlaps.cpp
@@ -1,0 +1,164 @@
+#include "Overlaps.hpp"
+
+#include <stdlib.h>
+#include <stdexcept>
+
+using std::to_string;
+using std::make_pair;
+using std::runtime_error;
+
+///
+/// M   I   D   N   S   H   P   =   X
+/// 0   1   2   3   4   5   6   7   8
+///
+
+
+    // 0   1   2   3   4   5   6   7   8   9
+const array<uint8_t, 128> CigarOperation::cigar_code = {
+    10, 10, 10, 10, 10, 10, 10, 10, 10, 10,  // 0
+    10, 10, 10, 10, 10, 10, 10, 10, 10, 10,  // 10
+    10, 10, 10, 10, 10, 10, 10, 10, 10, 10,  // 20
+    10, 10, 10, 10, 10, 10, 10, 10, 10, 10,  // 30
+    10, 10, 10, 10, 10, 10, 10, 10, 10, 10,  // 40
+    10, 10, 10, 10, 10, 10, 10, 10, 10, 10,  // 50
+    10, 7,  10, 10, 10, 10, 10, 10, 2,  10,  // 60    =61, D68
+    10, 10, 5,  1,  10, 10, 10, 0,  3,  10,  // 70    H72, I73, M77, N78
+    6,  10, 10, 4,  10, 10, 10, 10, 8,  10,  // 80    P80, S83, X88
+    10, 10, 10, 10, 10, 10, 10, 10, 10, 10,  // 90
+    10, 10, 10, 10, 10, 10, 10, 10, 10, 10,  // 100
+    10, 10, 10, 10, 10, 10, 10, 10, 10, 10,  // 110
+    10, 10, 10, 10, 10, 10, 10, 10};         // 120
+
+
+const array<bool, 9> CigarOperation::is_ref_move = {
+    true,      //MATCH      0
+    false,     //INS        1
+    true,      //DEL        2
+    true,      //REF_SKIP   3
+    false,     //SOFT_CLIP  4
+    false,     //HARD_CLIP  5
+    false,     //PAD        6
+    true,      //EQUAL      7
+    true};     //MISMATCH   8
+
+
+const array<bool, 9> CigarOperation::is_query_move = {
+    true,     //MATCH      0
+    true,     //INS        1
+    false,    //DEL        2
+    false,    //REF_SKIP   3
+    true,     //SOFT_CLIP  4
+    false,    //HARD_CLIP  5
+    false,    //PAD        6
+    true,     //EQUAL      7
+    true};    //MISMATCH   8
+
+const array<char, 9> CigarOperation::cigar_type = {'M','I','D','N','S','H','P','=','X'};
+
+
+CigarOperation::CigarOperation(uint32_t length, char type):
+    code(cigar_code[type]),
+    op_length(length)
+{
+    if (code > 8){
+        throw runtime_error("ERROR: unrecognized cigar character: " + string(1,type) + " has ASCII value: " + to_string(int(code)));
+    }
+}
+
+Cigar::Cigar(const std::string& cigar_string) {
+    
+    if (cigar_string == "*") {
+        // we handle the placeholder for an empy cigar from GFA
+        return;
+    }
+    
+    string token;
+    for (auto& c: cigar_string) {
+        if (isdigit(c)) {
+            token += c;
+        }
+        else {
+            auto len = stol(token);
+            if (len > 0) {
+                operations.emplace_back(len, c);
+                token.clear();
+            }
+        }
+    }
+}
+
+string Cigar::get_string() const {
+    
+    string s;
+    
+    // Count up the cigar operations
+    for (const auto& c: operations) {
+        s += to_string(c.length());
+        s += c.type();
+    }
+    
+    return s;
+}
+
+Cigar Cigar::reverse() const {
+    Cigar reversed;
+    for (auto it = operations.rbegin(); it != operations.rend(); ++it) {
+        if (it->type() == 'S' || it->type() == 'H' || it->type() == 'N' || it->type() == 'P') {
+            throw runtime_error("Clipped or unaligned CIGARs cannot be trivially reversed");
+        }
+        else if (it->type() == 'I') {
+            reversed.operations.emplace_back(it->length(), 'D');
+        }
+        else if (it->type() == 'D') {
+            reversed.operations.emplace_back(it->length(), 'I');
+        }
+        else {
+            reversed.operations.emplace_back(it->length(), it->type());
+        }
+    }
+    return reversed;
+}
+
+size_t Cigar::size() const {
+    return operations.size();
+}
+
+const CigarOperation& Cigar::at(size_t i) const {
+    return operations.at(i);
+}
+
+Cigar::iterator Cigar::begin() const {
+    return operations.begin();
+}
+
+Cigar::iterator Cigar::end() const {
+    return operations.end();
+}
+
+Overlaps::Overlaps(const HandleGraph& graph) : graph(&graph) {
+    
+}
+
+void Overlaps::record_overlap(handle_t a, handle_t b, const string& cigar) {
+    overlaps[graph->edge_handle(a, b)] = Cigar(cigar);
+}
+
+bool Overlaps::has_overlap(handle_t a, handle_t b) const {
+    return overlaps.count(graph->edge_handle(a, b));
+}
+
+Cigar Overlaps::get_overlap(handle_t a, handle_t b) const {
+    Cigar cigar;
+    auto it = overlaps.find(graph->edge_handle(a, b));
+    if (it != overlaps.end()) {
+        if (it->first.first == a) {
+            cigar = it->second;
+        }
+        else {
+            cigar = it->second.reverse();
+        }
+    }
+    return cigar;
+}
+
+

--- a/src/Overlaps.cpp
+++ b/src/Overlaps.cpp
@@ -66,6 +66,14 @@ CigarOperation::CigarOperation(uint32_t length, char type):
     }
 }
 
+char CigarOperation::type() const {
+    return cigar_type[code];
+}
+
+uint32_t CigarOperation::length() const {
+    return op_length;
+}
+
 Cigar::Cigar(const std::string& cigar_string) {
     
     if (cigar_string == "*") {

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -65,6 +65,7 @@ void write_chaining_info_to_file(
         const Bipartition& chain_bipartition,
         const PathHandleGraph& graph,
         const IncrementalIdMap<string>& id_map,
+        const Overlaps& overlaps,
         const string& filename_prefix,
         size_t component_index,
         bool write_gfa
@@ -75,7 +76,7 @@ void write_chaining_info_to_file(
     if (write_gfa) {
         path file_path = output_dir / "components" / to_string(c) / (filename_prefix + ".gfa");
         ofstream file(file_path);
-        handle_graph_to_gfa(graph, id_map, file);
+        handle_graph_to_gfa(graph, id_map, overlaps, file);
     }
 
     path test_gfa_chain_path = output_dir / "components" / to_string(c) / (filename_prefix + "chain_metagraph.gfa");
@@ -84,7 +85,7 @@ void write_chaining_info_to_file(
     if (not test_gfa_chain.is_open() or not test_gfa_chain.good()){
         throw runtime_error("ERROR: could not write to file: " + test_gfa_chain_path.string());
     }
-    handle_graph_to_gfa(chain_bipartition.metagraph, test_gfa_chain);
+    handle_graph_to_gfa(chain_bipartition.metagraph, test_gfa_chain, Overlaps());
 
     path test_csv_meta_chain_path = output_dir / "components" / to_string(c) / (filename_prefix + "chain_metagraph.csv");
     ofstream test_csv_meta_chain(test_csv_meta_chain_path);
@@ -151,7 +152,7 @@ void chain_phased_gfa(
         if (not test_gfa_meta.is_open() or not test_gfa_meta.good()){
             throw runtime_error("ERROR: could not write to file: " + test_gfa_meta_path.string());
         }
-        handle_graph_to_gfa(ploidy_bipartition.metagraph, test_gfa_meta);
+        handle_graph_to_gfa(ploidy_bipartition.metagraph, test_gfa_meta, Overlaps());
 
         path test_csv_meta_ploidy_path = output_dir / "components" / to_string(c) / (filename_prefix + "ploidy_metagraph.csv");
         ofstream test_csv_meta_ploidy(test_csv_meta_ploidy_path);
@@ -169,7 +170,7 @@ void chain_phased_gfa(
         }
         ploidy_bipartition.write_parent_graph_csv(test_csv_parent_ploidy);
 
-        write_chaining_info_to_file(output_dir, ploidy_bipartition, chain_bipartition, cc_graph, id_map, filename_prefix, c, write_gfa);
+        write_chaining_info_to_file(output_dir, ploidy_bipartition, chain_bipartition, cc_graph, id_map, overlaps, filename_prefix, c, write_gfa);
 
         merge_diploid_singletons(bubble_graph, chain_bipartition);
 
@@ -179,7 +180,7 @@ void chain_phased_gfa(
         if (not test_gfa_chain_merged.is_open() or not test_gfa_chain_merged.good()){
             throw runtime_error("ERROR: could not write to file: " + test_gfa_chain_merged_path.string());
         }
-        handle_graph_to_gfa(chain_bipartition.metagraph, test_gfa_chain_merged);
+        handle_graph_to_gfa(chain_bipartition.metagraph, test_gfa_chain_merged, Overlaps());
 
         path test_csv_meta_chain_merged_path = output_dir / "components" / to_string(c) / (filename_prefix + "chain_metagraph_merged.csv");
         ofstream test_csv_meta_chain_merged(test_csv_meta_chain_merged_path);
@@ -285,7 +286,7 @@ void chain_phased_gfa(
                 throw runtime_error("ERROR: could not write to file: " + test_gfa_phased_path.string());
             }
 
-            handle_graph_to_gfa(cc_graph, id_map, test_gfa_phased);
+            handle_graph_to_gfa(cc_graph, id_map, overlaps, test_gfa_phased);
         }
 
 

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -85,7 +85,7 @@ void write_chaining_info_to_file(
     if (not test_gfa_chain.is_open() or not test_gfa_chain.good()){
         throw runtime_error("ERROR: could not write to file: " + test_gfa_chain_path.string());
     }
-    handle_graph_to_gfa(chain_bipartition.metagraph, test_gfa_chain, Overlaps());
+    handle_graph_to_gfa(chain_bipartition.metagraph, test_gfa_chain);
 
     path test_csv_meta_chain_path = output_dir / "components" / to_string(c) / (filename_prefix + "chain_metagraph.csv");
     ofstream test_csv_meta_chain(test_csv_meta_chain_path);
@@ -152,7 +152,7 @@ void chain_phased_gfa(
         if (not test_gfa_meta.is_open() or not test_gfa_meta.good()){
             throw runtime_error("ERROR: could not write to file: " + test_gfa_meta_path.string());
         }
-        handle_graph_to_gfa(ploidy_bipartition.metagraph, test_gfa_meta, Overlaps());
+        handle_graph_to_gfa(ploidy_bipartition.metagraph, test_gfa_meta);
 
         path test_csv_meta_ploidy_path = output_dir / "components" / to_string(c) / (filename_prefix + "ploidy_metagraph.csv");
         ofstream test_csv_meta_ploidy(test_csv_meta_ploidy_path);
@@ -180,7 +180,7 @@ void chain_phased_gfa(
         if (not test_gfa_chain_merged.is_open() or not test_gfa_chain_merged.good()){
             throw runtime_error("ERROR: could not write to file: " + test_gfa_chain_merged_path.string());
         }
-        handle_graph_to_gfa(chain_bipartition.metagraph, test_gfa_chain_merged, Overlaps());
+        handle_graph_to_gfa(chain_bipartition.metagraph, test_gfa_chain_merged);
 
         path test_csv_meta_chain_merged_path = output_dir / "components" / to_string(c) / (filename_prefix + "chain_metagraph_merged.csv");
         ofstream test_csv_meta_chain_merged(test_csv_meta_chain_merged_path);

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -275,7 +275,7 @@ void chain_phased_gfa(
 
         write_paths_to_csv(cc_graph, id_map, provenance_csv_file);
 
-        unzip(cc_graph, id_map, false);
+        unzip(cc_graph, id_map, overlaps, false);
 
         if (write_gfa){
             // Write phased + unzipped gfa to file

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -106,15 +106,15 @@ void write_chaining_info_to_file(
 
 void chain_phased_gfa(
         MutablePathDeletableHandleGraph& graph,
-        IncrementalIdMap<string>& id_map, const
-        BubbleGraph& bubble_graph,
+        IncrementalIdMap<string>& id_map,
+        Overlaps& overlaps,
+        const BubbleGraph& bubble_graph,
         path output_dir,
         bool write_gfa,
         bool write_fasta
         ){
 
     vector<HashGraph> connected_components;
-    vector <IncrementalIdMap<string> > connected_component_ids;
 
     cerr << "Finding connected components..." << '\n';
 
@@ -123,7 +123,7 @@ void chain_phased_gfa(
     cerr << "Chaining phased bubbles..." << '\n';
 
     for (size_t c=0; c<connected_components.size(); c++){
-        unzip(connected_components[c], connected_component_ids[c], false);
+        unzip(connected_components[c], id_map, overlaps, false);
 
         auto& cc_graph = connected_components[c];
 

--- a/src/executable/compute_minhash2.cpp
+++ b/src/executable/compute_minhash2.cpp
@@ -17,7 +17,8 @@ int compute_minhash(path gfa_path, path output_directory, double sample_rate, si
 
     HashGraph graph;
     IncrementalIdMap<string> id_map;
-    gfa_to_handle_graph(graph, id_map, gfa_path);
+    Overlaps overlaps(graph);
+    gfa_to_handle_graph(graph, id_map, overlaps, gfa_path);
 
     Hasher2 hasher(k, sample_rate, n_iterations, n_threads);
 

--- a/src/executable/compute_minhash2.cpp
+++ b/src/executable/compute_minhash2.cpp
@@ -17,8 +17,8 @@ int compute_minhash(path gfa_path, path output_directory, double sample_rate, si
 
     HashGraph graph;
     IncrementalIdMap<string> id_map;
-    Overlaps overlaps(graph);
-    gfa_to_handle_graph(graph, id_map, overlaps, gfa_path);
+    Overlaps gfa_overlaps(graph);
+    gfa_to_handle_graph(graph, id_map, gfa_overlaps, gfa_path);
 
     Hasher2 hasher(k, sample_rate, n_iterations, n_threads);
 

--- a/src/executable/compute_minhash2.cpp
+++ b/src/executable/compute_minhash2.cpp
@@ -17,7 +17,7 @@ int compute_minhash(path gfa_path, path output_directory, double sample_rate, si
 
     HashGraph graph;
     IncrementalIdMap<string> id_map;
-    Overlaps gfa_overlaps(graph);
+    Overlaps gfa_overlaps;
     gfa_to_handle_graph(graph, id_map, gfa_overlaps, gfa_path);
 
     Hasher2 hasher(k, sample_rate, n_iterations, n_threads);

--- a/src/executable/count_kmers.cpp
+++ b/src/executable/count_kmers.cpp
@@ -34,9 +34,10 @@ void count_kmers(
 
     HashGraph graph;
     IncrementalIdMap<string> id_map;
+    Overlaps overlaps(graph);
     KmerSets <FixedBinarySequence <uint64_t, 2> > ks(paternal_kmers, maternal_kmers);
 
-    gfa_to_handle_graph(graph, id_map, gfa_path);
+    gfa_to_handle_graph(graph, id_map, overlaps, gfa_path);
 
     cerr << "Identifying diploid paths..." << '\n';
 

--- a/src/executable/count_kmers.cpp
+++ b/src/executable/count_kmers.cpp
@@ -34,7 +34,7 @@ void count_kmers(
 
     HashGraph graph;
     IncrementalIdMap<string> id_map;
-    Overlaps overlaps(graph);
+    Overlaps overlaps;
     KmerSets <FixedBinarySequence <uint64_t, 2> > ks(paternal_kmers, maternal_kmers);
 
     gfa_to_handle_graph(graph, id_map, overlaps, gfa_path);

--- a/src/executable/create_bandage_path_color_table.cpp
+++ b/src/executable/create_bandage_path_color_table.cpp
@@ -329,8 +329,9 @@ array<uint8_t,3> Colors::hex_to_rgb(string hex){
 void create_color_table(path gfa_path){
     HashGraph graph;
     IncrementalIdMap<string> id_map;
+    Overlaps overlaps(graph);
 
-    gfa_to_handle_graph(graph, id_map, gfa_path, false);
+    gfa_to_handle_graph(graph, id_map, overlaps, gfa_path, false);
 
     path out_path = gfa_path;
     out_path.replace_extension(".path_colors.csv");

--- a/src/executable/create_bandage_path_color_table.cpp
+++ b/src/executable/create_bandage_path_color_table.cpp
@@ -329,7 +329,7 @@ array<uint8_t,3> Colors::hex_to_rgb(string hex){
 void create_color_table(path gfa_path){
     HashGraph graph;
     IncrementalIdMap<string> id_map;
-    Overlaps overlaps(graph);
+    Overlaps overlaps;
 
     gfa_to_handle_graph(graph, id_map, overlaps, gfa_path, false);
 

--- a/src/executable/extract_haplotype_kmers.cpp
+++ b/src/executable/extract_haplotype_kmers.cpp
@@ -38,7 +38,7 @@ using std::cerr;
 void extract_haplotype_kmers_from_gfa(path gfa_path, size_t k){
     HashGraph graph;
     IncrementalIdMap<string> id_map;
-    Overlaps overlaps(graph);
+    Overlaps overlaps;
 
     gfa_to_handle_graph(graph, id_map, overlaps, gfa_path);
 

--- a/src/executable/extract_haplotype_kmers.cpp
+++ b/src/executable/extract_haplotype_kmers.cpp
@@ -38,8 +38,9 @@ using std::cerr;
 void extract_haplotype_kmers_from_gfa(path gfa_path, size_t k){
     HashGraph graph;
     IncrementalIdMap<string> id_map;
+    Overlaps overlaps(graph);
 
-    gfa_to_handle_graph(graph, id_map, gfa_path);
+    gfa_to_handle_graph(graph, id_map, overlaps, gfa_path);
 
     plot_graph(graph, "start_graph");
 

--- a/src/executable/find_bubbles.cpp
+++ b/src/executable/find_bubbles.cpp
@@ -41,8 +41,9 @@ void find_bubbles_in_gfa(path output_dir, path gfa_path){
 
     HashGraph graph;
     IncrementalIdMap<string> id_map;
+    Overlaps overlaps(graph);
 
-    gfa_to_handle_graph(graph, id_map, gfa_path, false);
+    gfa_to_handle_graph(graph, id_map, overlaps, gfa_path, false);
 
     BubbleGraph bubble_graph(graph);
 

--- a/src/executable/find_bubbles.cpp
+++ b/src/executable/find_bubbles.cpp
@@ -41,7 +41,7 @@ void find_bubbles_in_gfa(path output_dir, path gfa_path){
 
     HashGraph graph;
     IncrementalIdMap<string> id_map;
-    Overlaps overlaps(graph);
+    Overlaps overlaps;
 
     gfa_to_handle_graph(graph, id_map, overlaps, gfa_path, false);
 

--- a/src/executable/find_shasta_bubbles.cpp
+++ b/src/executable/find_shasta_bubbles.cpp
@@ -43,7 +43,7 @@ void find_bubbles_in_gfa(path output_dir, path gfa_path){
 
     HashGraph graph;
     IncrementalIdMap<string> id_map;
-    Overlaps overlaps(graph);
+    Overlaps overlaps;
     
     gfa_to_handle_graph(graph, id_map, overlaps, gfa_path, false);
 

--- a/src/executable/find_shasta_bubbles.cpp
+++ b/src/executable/find_shasta_bubbles.cpp
@@ -52,7 +52,7 @@ void find_bubbles_in_gfa(path output_dir, path gfa_path){
     path output_path = output_dir / "bubbles.csv";
     bubble_graph.write_bandage_csv(output_path, id_map);
 
-    chain_phased_gfa(graph, id_map, bubble_graph, output_dir);
+    chain_phased_gfa(graph, id_map, overlaps, bubble_graph, output_dir);
 }
 
 

--- a/src/executable/find_shasta_bubbles.cpp
+++ b/src/executable/find_shasta_bubbles.cpp
@@ -43,8 +43,9 @@ void find_bubbles_in_gfa(path output_dir, path gfa_path){
 
     HashGraph graph;
     IncrementalIdMap<string> id_map;
-
-    gfa_to_handle_graph(graph, id_map, gfa_path, false);
+    Overlaps overlaps(graph);
+    
+    gfa_to_handle_graph(graph, id_map, overlaps, gfa_path, false);
 
     BubbleGraph bubble_graph(id_map);
 

--- a/src/executable/get_degree_stats.cpp
+++ b/src/executable/get_degree_stats.cpp
@@ -32,8 +32,9 @@ using std::cerr;
 void get_degree_stats(path gfa_path){
     HashGraph graph;
     IncrementalIdMap<string> id_map;
+    Overlaps overlaps(graph);
 
-    gfa_to_handle_graph(graph, id_map, gfa_path, false);
+    gfa_to_handle_graph(graph, id_map, overlaps, gfa_path, false);
 
     map<size_t,size_t> degree_counts;
 

--- a/src/executable/get_degree_stats.cpp
+++ b/src/executable/get_degree_stats.cpp
@@ -32,7 +32,7 @@ using std::cerr;
 void get_degree_stats(path gfa_path){
     HashGraph graph;
     IncrementalIdMap<string> id_map;
-    Overlaps overlaps(graph);
+    Overlaps overlaps;
 
     gfa_to_handle_graph(graph, id_map, overlaps, gfa_path, false);
 

--- a/src/executable/get_path_lengths.cpp
+++ b/src/executable/get_path_lengths.cpp
@@ -33,8 +33,9 @@ using std::cerr;
 int get_path_lengths(path gfa_path){
     HashGraph graph;
     IncrementalIdMap<string> id_map;
+    Overlaps overlaps(graph);
 
-    gfa_to_handle_graph(graph, id_map, gfa_path, false);
+    gfa_to_handle_graph(graph, id_map, overlaps, gfa_path, false);
 
     graph.for_each_path_handle([&](const path_handle_t& p) {
         cerr << graph.get_path_name(p) << ": ";

--- a/src/executable/get_path_lengths.cpp
+++ b/src/executable/get_path_lengths.cpp
@@ -33,7 +33,7 @@ using std::cerr;
 int get_path_lengths(path gfa_path){
     HashGraph graph;
     IncrementalIdMap<string> id_map;
-    Overlaps overlaps(graph);
+    Overlaps overlaps;
 
     gfa_to_handle_graph(graph, id_map, overlaps, gfa_path, false);
 

--- a/src/executable/locate_kmer_matches.cpp
+++ b/src/executable/locate_kmer_matches.cpp
@@ -49,7 +49,7 @@ void locate_kmer_matches(
 
     HashGraph graph;
     IncrementalIdMap<string> id_map;
-    Overlaps overlaps(graph);
+    Overlaps overlaps;
 
     cerr << "Loading kmers into sets..." << '\n';
     KmerSets<FixedBinarySequence<uint64_t, 2> > ks(paternal_kmers, maternal_kmers);

--- a/src/executable/locate_kmer_matches.cpp
+++ b/src/executable/locate_kmer_matches.cpp
@@ -49,11 +49,12 @@ void locate_kmer_matches(
 
     HashGraph graph;
     IncrementalIdMap<string> id_map;
+    Overlaps overlaps(graph);
 
     cerr << "Loading kmers into sets..." << '\n';
     KmerSets<FixedBinarySequence<uint64_t, 2> > ks(paternal_kmers, maternal_kmers);
 
-    gfa_to_handle_graph(graph, id_map, gfa_path);
+    gfa_to_handle_graph(graph, id_map, overlaps, gfa_path);
 
 //    plot_graph(graph, "start_graph");
 

--- a/src/executable/phase_contacts.cpp
+++ b/src/executable/phase_contacts.cpp
@@ -236,7 +236,7 @@ void phase_hic(path output_dir, path sam_path, path gfa_path, string required_pr
 
     HashGraph graph;
     // The overlaps between sequences in the GFA
-    Overlaps overlaps(graph);
+    Overlaps overlaps;
 
     // To keep track of pairs of segments which exist in diploid bubbles
     BubbleGraph bubble_graph;

--- a/src/executable/phase_contacts.cpp
+++ b/src/executable/phase_contacts.cpp
@@ -273,7 +273,7 @@ void phase_hic(path output_dir, path sam_path, path gfa_path, string required_pr
     bubble_graph.write_bandage_csv(phases_output_path, id_map);
 
     if (not gfa_path.empty()){
-        chain_phased_gfa(graph, id_map, bubble_graph, output_dir);
+        chain_phased_gfa(graph, id_map, overlaps, bubble_graph, output_dir);
     }
 
     cerr << t << "Done" << '\n';

--- a/src/executable/phase_contacts.cpp
+++ b/src/executable/phase_contacts.cpp
@@ -235,6 +235,8 @@ void phase_hic(path output_dir, path sam_path, path gfa_path, string required_pr
     }
 
     HashGraph graph;
+    // The overlaps between sequences in the GFA
+    Overlaps overlaps(graph);
 
     // To keep track of pairs of segments which exist in diploid bubbles
     BubbleGraph bubble_graph;
@@ -249,7 +251,7 @@ void phase_hic(path output_dir, path sam_path, path gfa_path, string required_pr
         cerr << t << "GFA provided - Loading graph..." << '\n';
 
         // Construct graph from GFA
-        gfa_to_handle_graph(graph, id_map, gfa_path, false);
+        gfa_to_handle_graph(graph, id_map, overlaps, gfa_path, false);
 
         cerr << t << "Constructing bubble graph..." << '\n';
 

--- a/src/executable/phase_contacts_with_monte_carlo.cpp
+++ b/src/executable/phase_contacts_with_monte_carlo.cpp
@@ -202,14 +202,14 @@ void write_config(
 }
 
 
-void write_gfa_to_file(PathHandleGraph& graph, IncrementalIdMap<string>& id_map, path output_gfa_path){
+void write_gfa_to_file(PathHandleGraph& graph, IncrementalIdMap<string>& id_map, Overlaps& overlaps, path output_gfa_path){
     ofstream chained_gfa(output_gfa_path);
 
     if (not (chained_gfa.is_open() and chained_gfa.good())){
         throw runtime_error("ERROR: could not write to file: " + output_gfa_path.string());
     }
 
-    handle_graph_to_gfa(graph, id_map, chained_gfa);
+    handle_graph_to_gfa(graph, id_map, overlaps, chained_gfa);
 
 }
 
@@ -538,13 +538,13 @@ void phase(
 
     cerr << t << "Writing GFA... " << '\n';
 
-    write_gfa_to_file(graph, id_map, chained_gfa_path);
+    write_gfa_to_file(graph, id_map, overlaps, chained_gfa_path);
 
     if (not skip_unzip) {
         cerr << t << "Unzipping chains... " << '\n';
 
-        unzip(graph, id_map, false, false);
-        write_gfa_to_file(graph, id_map, unzipped_gfa_path);
+        unzip(graph, id_map, overlaps, false, false);
+        write_gfa_to_file(graph, id_map, overlaps, unzipped_gfa_path);
     }
 
     cerr << t << "Writing FASTA... " << '\n';

--- a/src/executable/phase_contacts_with_monte_carlo.cpp
+++ b/src/executable/phase_contacts_with_monte_carlo.cpp
@@ -451,7 +451,7 @@ void phase(
     HashGraph graph;
     
     // Overlaps between the sequences
-    Overlaps overlaps(graph);
+    Overlaps overlaps;
 
     // To keep track of pairs of segments which exist in diploid bubbles
     MultiContactGraph contact_graph;
@@ -511,7 +511,7 @@ void phase(
     contact_graph.write_contact_map(contacts_output_path, id_map);
 
     // Remove self edges in contact graph (now that they have been written to disk)
-    contact_graph.for_each_node([&](int32_t id){
+    contact_graph.for_each_node([&](int32_t id) {
         contact_graph.remove_edge(id,id);
     });
 

--- a/src/executable/phase_contacts_with_monte_carlo.cpp
+++ b/src/executable/phase_contacts_with_monte_carlo.cpp
@@ -449,6 +449,9 @@ void phase(
 
     // How GFA is stored in memory
     HashGraph graph;
+    
+    // Overlaps between the sequences
+    Overlaps overlaps(graph);
 
     // To keep track of pairs of segments which exist in diploid bubbles
     MultiContactGraph contact_graph;

--- a/src/executable/phase_contacts_with_monte_carlo.cpp
+++ b/src/executable/phase_contacts_with_monte_carlo.cpp
@@ -468,7 +468,7 @@ void phase(
     cerr << t << "Loading GFA..." << '\n';
 
     // Construct graph from GFA
-    gfa_to_handle_graph(graph, id_map, gfa_path, false, true);
+    gfa_to_handle_graph(graph, id_map, overlaps, gfa_path, false, true);
 
     cerr << t << "Writing IDs to file..." << '\n';
 

--- a/src/executable/remove_empty_nodes.cpp
+++ b/src/executable/remove_empty_nodes.cpp
@@ -109,9 +109,10 @@ void splice_out_empty_nodes(MutablePathDeletableHandleGraph& graph){
 void clean_gfa(path gfa_path){
     HashGraph graph;
     IncrementalIdMap<string> id_map;
+    Overlaps overlaps(graph);
 
     cerr << "Loading GFA..." << '\n';
-    gfa_to_handle_graph(graph, id_map, gfa_path);
+    gfa_to_handle_graph(graph, id_map, overlaps, gfa_path);
 
     splice_out_empty_nodes(graph);
 

--- a/src/executable/remove_empty_nodes.cpp
+++ b/src/executable/remove_empty_nodes.cpp
@@ -121,7 +121,7 @@ void clean_gfa(path gfa_path){
 
     cerr << "Writing to GFA: " << output_path << '\n';
     ofstream file(output_path);
-    handle_graph_to_gfa(graph, id_map, file);
+    handle_graph_to_gfa(graph, id_map, overlaps, file);
 }
 
 

--- a/src/executable/remove_empty_nodes.cpp
+++ b/src/executable/remove_empty_nodes.cpp
@@ -109,7 +109,7 @@ void splice_out_empty_nodes(MutablePathDeletableHandleGraph& graph){
 void clean_gfa(path gfa_path){
     HashGraph graph;
     IncrementalIdMap<string> id_map;
-    Overlaps overlaps(graph);
+    Overlaps overlaps;
 
     cerr << "Loading GFA..." << '\n';
     gfa_to_handle_graph(graph, id_map, overlaps, gfa_path);

--- a/src/executable/split_connected_components.cpp
+++ b/src/executable/split_connected_components.cpp
@@ -36,7 +36,7 @@ using std::cerr;
 void split_gfa_components(path gfa_path){
     HashGraph graph;
     IncrementalIdMap<string> id_map;
-    Overlaps overlaps(graph);
+    Overlaps overlaps;
 
     cerr << "Loading GFA..." << '\n';
     gfa_to_handle_graph(graph, id_map, overlaps, gfa_path);

--- a/src/executable/split_connected_components.cpp
+++ b/src/executable/split_connected_components.cpp
@@ -46,7 +46,7 @@ void split_gfa_components(path gfa_path){
     cerr << "Writing subgraph GFAs to: " << output_directory << '\n';
     create_directories(output_directory);
 
-    write_connected_components_to_gfas(graph, id_map, output_directory);
+    write_connected_components_to_gfas(graph, id_map, overlaps, output_directory);
 }
 
 

--- a/src/executable/split_connected_components.cpp
+++ b/src/executable/split_connected_components.cpp
@@ -36,9 +36,10 @@ using std::cerr;
 void split_gfa_components(path gfa_path){
     HashGraph graph;
     IncrementalIdMap<string> id_map;
+    Overlaps overlaps(graph);
 
     cerr << "Loading GFA..." << '\n';
-    gfa_to_handle_graph(graph, id_map, gfa_path);
+    gfa_to_handle_graph(graph, id_map, overlaps, gfa_path);
 
     path output_directory = gfa_path.parent_path() / gfa_path.stem();
 

--- a/src/executable/unzip.cpp
+++ b/src/executable/unzip.cpp
@@ -33,7 +33,7 @@ using std::cerr;
 void unzip_gfa(path gfa_path){
     HashGraph graph;
     IncrementalIdMap<string> id_map;
-    Overlaps overlaps(graph);
+    Overlaps overlaps;
 
     gfa_to_handle_graph(graph, id_map, overlaps, gfa_path);
 
@@ -42,8 +42,9 @@ void unzip_gfa(path gfa_path){
 
     vector<HashGraph> connected_components;
     vector <IncrementalIdMap<string> > connected_component_ids;
+    vector<Overlaps> connected_component_overlaps;
 
-    split_connected_components(graph, id_map, connected_components, connected_component_ids);
+    split_connected_components(graph, id_map, overlaps, connected_components, connected_component_ids, connected_component_overlaps);
 
     for (size_t i=0; i<connected_components.size(); i++){
         cerr << "Component " << to_string(i) << '\n';

--- a/src/executable/unzip.cpp
+++ b/src/executable/unzip.cpp
@@ -35,7 +35,7 @@ void unzip_gfa(path gfa_path){
     IncrementalIdMap<string> id_map;
     Overlaps overlaps(graph);
 
-    gfa_to_handle_graph(graph, id_map, gfa_path);
+    gfa_to_handle_graph(graph, id_map, overlaps, gfa_path);
 
     // Output an image of the graph, can be uncommented for debugging
 //    plot_graph(graph, "test_unzip_unedited");

--- a/src/executable/unzip.cpp
+++ b/src/executable/unzip.cpp
@@ -54,7 +54,7 @@ void unzip_gfa(path gfa_path){
 
         string filename_prefix = "component_" + to_string(i) + "_unzipped";
         ofstream file(filename_prefix + ".gfa");
-        handle_graph_to_gfa(connected_components[i], connected_component_ids[i], file);
+        handle_graph_to_gfa(connected_components[i], connected_component_ids[i], connected_component_overlaps[i], file);
     }
 }
 

--- a/src/executable/unzip.cpp
+++ b/src/executable/unzip.cpp
@@ -33,6 +33,7 @@ using std::cerr;
 void unzip_gfa(path gfa_path){
     HashGraph graph;
     IncrementalIdMap<string> id_map;
+    Overlaps overlaps(graph);
 
     gfa_to_handle_graph(graph, id_map, gfa_path);
 

--- a/src/executable/unzip.cpp
+++ b/src/executable/unzip.cpp
@@ -50,7 +50,7 @@ void unzip_gfa(path gfa_path){
         cerr << "Component " << to_string(i) << '\n';
         print_graph_paths(connected_components[i], connected_component_ids[i]);
 
-        unzip(connected_components[i], connected_component_ids[i]);
+        unzip(connected_components[i], connected_component_ids[i], connected_component_overlaps[i]);
 
         string filename_prefix = "component_" + to_string(i) + "_unzipped";
         ofstream file(filename_prefix + ".gfa");

--- a/src/gfa_to_handle.cpp
+++ b/src/gfa_to_handle.cpp
@@ -27,6 +27,7 @@ nid_t parse_gfa_sequence_id(const string& s, IncrementalIdMap<string>& id_map) {
 void gfa_to_handle_graph(
         MutablePathMutableHandleGraph& graph,
         IncrementalIdMap<string>& id_map,
+        Overlaps& overlaps,
         path gfa_file_path,
         bool ignore_singleton_paths,
         bool ignore_paths
@@ -62,14 +63,7 @@ void gfa_to_handle_graph(
         handle_t a = graph.get_handle(source_id, reversal_a);
         handle_t b = graph.get_handle(sink_id, reversal_b);
         graph.create_edge(a, b);
-
-        if (cigar == "0M" or cigar == "*") {
-            graph.create_edge(a, b);
-        }
-//        else{
-//            throw runtime_error("ERROR: gfa link (" + node_a + "->" + node_b + ") "
-//                                "contains non-empty overlap: " + cigar);
-//        }
+        overlaps.record_overlap(a, b, cigar);
     });
 
     if (ignore_paths){

--- a/src/gfa_to_handle.cpp
+++ b/src/gfa_to_handle.cpp
@@ -63,7 +63,7 @@ void gfa_to_handle_graph(
         handle_t a = graph.get_handle(source_id, reversal_a);
         handle_t b = graph.get_handle(sink_id, reversal_b);
         graph.create_edge(a, b);
-        overlaps.record_overlap(a, b, cigar);
+        overlaps.record_overlap(graph, a, b, cigar);
     });
 
     if (ignore_paths){

--- a/src/graph_utility.cpp
+++ b/src/graph_utility.cpp
@@ -623,6 +623,7 @@ void split_connected_components(
 void write_connected_components_to_gfas(
         const MutablePathDeletableHandleGraph& graph,
         const IncrementalIdMap<string>& id_map,
+        const Overlaps& overlaps,
         path output_directory) {
 
     unordered_set<nid_t> all_nodes;
@@ -660,7 +661,7 @@ void write_connected_components_to_gfas(
 
         // Duplicate all the edges
         for_edge_in_bfs(graph, start_node, [&](const handle_t& handle_a, const handle_t& handle_b) {
-            write_edge_to_gfa(graph, id_map, {handle_a, handle_b}, file);
+            write_edge_to_gfa(graph, id_map, overlaps, {handle_a, handle_b}, file);
         });
 
         // Duplicate all the paths

--- a/src/graph_utility.cpp
+++ b/src/graph_utility.cpp
@@ -898,6 +898,8 @@ void unzip(MutablePathDeletableHandleGraph& graph, IncrementalIdMap<string>& id_
         paths.emplace_back(p);
 //        cerr << graph.get_path_name(p) << '\n';
     });
+    
+    vector<path_handle_t> haplotype_paths;
 
     for (auto& p: paths){
         
@@ -981,11 +983,11 @@ void unzip(MutablePathDeletableHandleGraph& graph, IncrementalIdMap<string>& id_
         // Replace the old path with the new node
         bool is_circular = graph.get_is_circular(p);
         graph.destroy_path(p);
-        if (keep_paths) {
-            auto haplotype_path_handle = graph.create_path_handle(name);
-            graph.append_step(haplotype_path_handle, haplotype_handle);
-            graph.set_circularity(haplotype_path_handle, is_circular);
-        }
+        auto haplotype_path_handle = graph.create_path_handle(name);
+        graph.append_step(haplotype_path_handle, haplotype_handle);
+        graph.set_circularity(haplotype_path_handle, is_circular);
+        
+        haplotype_paths.push_back(haplotype_path_handle);
     }
 
     // Destroy the nodes that have had their sequences duplicated into haplotypes
@@ -1030,6 +1032,14 @@ void unzip(MutablePathDeletableHandleGraph& graph, IncrementalIdMap<string>& id_
                 }
             }
         });
+    }
+    
+    // we no longer need the haplotype paths for island identification, so we could
+    // get rid of them now
+    if (!keep_paths) {
+        for (auto path : haplotype_paths) {
+            graph.destroy_path(path);
+        }
     }
 }
 

--- a/src/handle_to_gfa.cpp
+++ b/src/handle_to_gfa.cpp
@@ -78,16 +78,17 @@ void write_path_to_gfa(const PathHandleGraph& graph, const IncrementalIdMap<stri
 
 
 /// With no consideration for directionality, just dump all the edges/nodes into GFA format
-void handle_graph_to_gfa(const HandleGraph& graph, const Overlaps& overlaps, ostream& output_gfa){
+void handle_graph_to_gfa(const HandleGraph& graph, ostream& output_gfa){
 
     output_gfa << "H\tHVN:Z:1.0\n";
 
+    Overlaps null;
     graph.for_each_handle([&](const handle_t& node){
         write_node_to_gfa(graph, node, output_gfa);
     });
 
     graph.for_each_edge([&](const edge_t& edge){
-        write_edge_to_gfa(graph, overlaps, edge, output_gfa);
+        write_edge_to_gfa(graph, null, edge, output_gfa);
     });
 
     output_gfa << std::flush;

--- a/src/handle_to_gfa.cpp
+++ b/src/handle_to_gfa.cpp
@@ -32,17 +32,17 @@ void write_node_to_gfa(const HandleGraph& graph, const IncrementalIdMap<string>&
 }
 
 
-void write_edge_to_gfa(const HandleGraph& graph, const edge_t& edge, ostream& output_file){
+void write_edge_to_gfa(const HandleGraph& graph, const Overlaps& overlaps, const edge_t& edge, ostream& output_file){
     output_file << "L\t" << graph.get_id(edge.first) << '\t' << get_reversal_character(graph, edge.first) << '\t'
                 << graph.get_id(edge.second) << '\t' << get_reversal_character(graph, edge.second) << '\t'
-                << "0M" << '\n';
+                << overlaps.get_overlap(graph, edge.first, edge.second).get_string() << '\n';
 }
 
 
-void write_edge_to_gfa(const HandleGraph& graph, const IncrementalIdMap<string>& id_map, const edge_t& edge, ostream& output_file){
+void write_edge_to_gfa(const HandleGraph& graph, const IncrementalIdMap<string>& id_map, const Overlaps& overlaps, const edge_t& edge, ostream& output_file){
     output_file << "L\t" << id_map.get_name(graph.get_id(edge.first)) << '\t' << get_reversal_character(graph, edge.first) << '\t'
                 << id_map.get_name(graph.get_id(edge.second)) << '\t' << get_reversal_character(graph, edge.second) << '\t'
-                << "0M" << '\n';
+                << overlaps.get_overlap(graph, edge.first, edge.second).get_string() << '\n';
 }
 
 
@@ -78,7 +78,7 @@ void write_path_to_gfa(const PathHandleGraph& graph, const IncrementalIdMap<stri
 
 
 /// With no consideration for directionality, just dump all the edges/nodes into GFA format
-void handle_graph_to_gfa(const HandleGraph& graph, ostream& output_gfa){
+void handle_graph_to_gfa(const HandleGraph& graph, const Overlaps& overlaps, ostream& output_gfa){
 
     output_gfa << "H\tHVN:Z:1.0\n";
 
@@ -87,7 +87,7 @@ void handle_graph_to_gfa(const HandleGraph& graph, ostream& output_gfa){
     });
 
     graph.for_each_edge([&](const edge_t& edge){
-        write_edge_to_gfa(graph, edge, output_gfa);
+        write_edge_to_gfa(graph, overlaps, edge, output_gfa);
     });
 
     output_gfa << std::flush;
@@ -95,7 +95,7 @@ void handle_graph_to_gfa(const HandleGraph& graph, ostream& output_gfa){
 
 
 /// With no consideration for directionality, just dump all the edges/nodes into GFA format
-void handle_graph_to_gfa(const PathHandleGraph& graph, const IncrementalIdMap<string>& id_map, ostream& output_gfa){
+void handle_graph_to_gfa(const PathHandleGraph& graph, const IncrementalIdMap<string>& id_map, const Overlaps& overlaps, ostream& output_gfa){
 
     output_gfa << "H\tHVN:Z:1.0\n";
 
@@ -104,7 +104,7 @@ void handle_graph_to_gfa(const PathHandleGraph& graph, const IncrementalIdMap<st
     });
 
     graph.for_each_edge([&](const edge_t& edge){
-        write_edge_to_gfa(graph, id_map, edge, output_gfa);
+        write_edge_to_gfa(graph, id_map, overlaps, edge, output_gfa);
     });
 
     graph.for_each_path_handle([&](const path_handle_t& path) {

--- a/src/test/test_bfs.cpp
+++ b/src/test/test_bfs.cpp
@@ -37,7 +37,7 @@ int main(){
 
     HashGraph graph;
     IncrementalIdMap<string> id_map;
-    Overlaps overlaps(graph);
+    Overlaps overlaps;
 
     gfa_to_handle_graph(graph, id_map, overlaps, absolute_gfa_path);
 

--- a/src/test/test_bfs.cpp
+++ b/src/test/test_bfs.cpp
@@ -37,8 +37,9 @@ int main(){
 
     HashGraph graph;
     IncrementalIdMap<string> id_map;
+    Overlaps overlaps(graph);
 
-    gfa_to_handle_graph(graph, id_map, absolute_gfa_path);
+    gfa_to_handle_graph(graph, id_map, overlaps, absolute_gfa_path);
 
     set<string> bfs_node_names;
     for_node_in_bfs(graph, 1, [&](const handle_t& h){

--- a/src/test/test_bridges.cpp
+++ b/src/test/test_bridges.cpp
@@ -36,7 +36,7 @@ void run_test(string& data_file,
     
     HashGraph graph;
     IncrementalIdMap<string> id_map;
-    Overlaps overlaps(graph);
+    Overlaps overlaps;
     
     gfa_to_handle_graph(graph, id_map, overlaps, absolute_gfa_path);
     

--- a/src/test/test_bridges.cpp
+++ b/src/test/test_bridges.cpp
@@ -36,8 +36,9 @@ void run_test(string& data_file,
     
     HashGraph graph;
     IncrementalIdMap<string> id_map;
+    Overlaps overlaps(graph);
     
-    gfa_to_handle_graph(graph, id_map, absolute_gfa_path);
+    gfa_to_handle_graph(graph, id_map, overlaps, absolute_gfa_path);
     
     vector<handle_t> bridges;
     set<string> bridge_names;

--- a/src/test/test_bubble_align.cpp
+++ b/src/test/test_bubble_align.cpp
@@ -35,7 +35,8 @@ void infer_bubbles_from_alignment(
     IncrementalIdMap<string> id_map(false);
 
     HashGraph graph;
-    gfa_to_handle_graph(graph, id_map, gfa_path);
+    Overlaps overlaps(graph);
+    gfa_to_handle_graph(graph, id_map, overlaps, gfa_path);
 
     // Hashing params
     double sample_rate = 0.04;

--- a/src/test/test_bubble_align.cpp
+++ b/src/test/test_bubble_align.cpp
@@ -35,7 +35,7 @@ void infer_bubbles_from_alignment(
     IncrementalIdMap<string> id_map(false);
 
     HashGraph graph;
-    Overlaps overlaps(graph);
+    Overlaps overlaps;
     gfa_to_handle_graph(graph, id_map, overlaps, gfa_path);
 
     // Hashing params

--- a/src/test/test_bubblegraph_chaining.cpp
+++ b/src/test/test_bubblegraph_chaining.cpp
@@ -125,7 +125,7 @@ void chain(path output_dir, path gfa_path, size_t n_threads, bool use_topology, 
     bubble_graph.write_bandage_csv(phases_output_path, id_map);
 
     if (not gfa_path.empty()){
-        chain_phased_gfa(graph, id_map, bubble_graph, output_dir, write_sequence, write_sequence);
+        chain_phased_gfa(graph, id_map, overlaps, bubble_graph, output_dir, write_sequence, write_sequence);
     }
 
     cerr << t << "Done" << '\n';

--- a/src/test/test_bubblegraph_chaining.cpp
+++ b/src/test/test_bubblegraph_chaining.cpp
@@ -88,7 +88,7 @@ void chain(path output_dir, path gfa_path, size_t n_threads, bool use_topology, 
     IncrementalIdMap<string> id_map(false);
 
     HashGraph graph;
-    Overlaps overlaps(graph);
+    Overlaps overlaps;
 
     // To keep track of pairs of segments which exist in diploid bubbles
     BubbleGraph bubble_graph;

--- a/src/test/test_bubblegraph_chaining.cpp
+++ b/src/test/test_bubblegraph_chaining.cpp
@@ -88,6 +88,7 @@ void chain(path output_dir, path gfa_path, size_t n_threads, bool use_topology, 
     IncrementalIdMap<string> id_map(false);
 
     HashGraph graph;
+    Overlaps overlaps(graph);
 
     // To keep track of pairs of segments which exist in diploid bubbles
     BubbleGraph bubble_graph;
@@ -102,7 +103,7 @@ void chain(path output_dir, path gfa_path, size_t n_threads, bool use_topology, 
         cerr << t << "GFA provided - Loading graph..." << '\n';
 
         // Construct graph from GFA
-        gfa_to_handle_graph(graph, id_map, gfa_path, false);
+        gfa_to_handle_graph(graph, id_map, overlaps, gfa_path, false);
 
         cerr << t << "Constructing bubble graph..." << '\n';
 

--- a/src/test/test_chainer.cpp
+++ b/src/test/test_chainer.cpp
@@ -94,7 +94,7 @@ void chain(path output_dir, path gfa_path){
         throw runtime_error("ERROR: could not write to file: " + chained_gfa_path.string());
     }
 
-    handle_graph_to_gfa(graph, id_map, chained_gfa);
+    handle_graph_to_gfa(graph, id_map, overlaps, chained_gfa);
 
     unzip(graph, id_map, overlaps, false, false);
 
@@ -107,7 +107,7 @@ void chain(path output_dir, path gfa_path){
         throw runtime_error("ERROR: could not write to file: " + unzipped_gfa_path.string());
     }
 
-    handle_graph_to_gfa(graph, id_map, unzipped_gfa);
+    handle_graph_to_gfa(graph, id_map, overlaps, unzipped_gfa);
 }
 
 

--- a/src/test/test_chainer.cpp
+++ b/src/test/test_chainer.cpp
@@ -96,7 +96,7 @@ void chain(path output_dir, path gfa_path){
 
     handle_graph_to_gfa(graph, id_map, chained_gfa);
 
-    unzip(graph, id_map, false, false);
+    unzip(graph, id_map, overlaps, false, false);
 
     chainer.write_chaining_results_to_bandage_csv(output_dir, id_map, contact_graph);
 

--- a/src/test/test_chainer.cpp
+++ b/src/test/test_chainer.cpp
@@ -60,7 +60,7 @@ void chain(path output_dir, path gfa_path){
     // Id-to-name bimap for reference contigs
     IncrementalIdMap<string> id_map(false);
     HashGraph graph;
-    Overlaps overlaps(graph);
+    Overlaps overlaps;
     MultiContactGraph contact_graph;
     Chainer chainer;
 

--- a/src/test/test_chainer.cpp
+++ b/src/test/test_chainer.cpp
@@ -60,11 +60,12 @@ void chain(path output_dir, path gfa_path){
     // Id-to-name bimap for reference contigs
     IncrementalIdMap<string> id_map(false);
     HashGraph graph;
+    Overlaps overlaps(graph);
     MultiContactGraph contact_graph;
     Chainer chainer;
 
     // Construct graph from GFA
-    gfa_to_handle_graph(graph, id_map, gfa_path, false, true);
+    gfa_to_handle_graph(graph, id_map, overlaps, gfa_path, false, true);
 
     chainer.find_chainable_nodes(graph, id_map);
     chainer.harmonize_chain_orientations(graph);

--- a/src/test/test_connected_component_finder.cpp
+++ b/src/test/test_connected_component_finder.cpp
@@ -37,8 +37,9 @@ int main(){
 
     HashGraph graph;
     IncrementalIdMap<string> id_map;
+    Overlaps overlaps(graph);
 
-    gfa_to_handle_graph(graph, id_map, absolute_gfa_path);
+    gfa_to_handle_graph(graph, id_map, overlaps, absolute_gfa_path);
 
     unordered_set<string> cc1 = {"a", "b", "c"};
     unordered_set<string> cc2 = {"d", "e"};

--- a/src/test/test_connected_component_finder.cpp
+++ b/src/test/test_connected_component_finder.cpp
@@ -41,10 +41,12 @@ int main(){
 
     gfa_to_handle_graph(graph, id_map, overlaps, absolute_gfa_path);
 
-    unordered_set<string> cc1 = {"a", "b", "c"};
-    unordered_set<string> cc2 = {"d", "e"};
+    unordered_set<string> cc1 = {"a", "b", "c", "d"};
+    unordered_set<string> cc2 = {"e", "f"};
+    unordered_set<string> cc3 = {"g", "h"};
     bool found_cc1 = false;
     bool found_cc2 = false;
+    bool found_cc3 = false;
 
     for_each_connected_component(graph, [&](unordered_set<nid_t>& connected_component){
         unordered_set<string> cc;
@@ -60,6 +62,9 @@ int main(){
         else if (cc == cc2){
             found_cc2 = true;
         }
+        else if (cc == cc3){
+            found_cc3 = true;
+        }
         else{
             cerr << "BAD COMPONENT:" << '\n';
             for (auto& item: cc){
@@ -72,9 +77,13 @@ int main(){
     if (not found_cc1){
         throw runtime_error("FAIL: cc1 not found");
     }
-
+    
     if (not found_cc2){
         throw runtime_error("FAIL: cc2 not found");
+    }
+    
+    if (not found_cc3){
+        throw runtime_error("FAIL: cc3 not found");
     }
 
     vector<HashGraph> connected_component_graphs;

--- a/src/test/test_connected_component_finder.cpp
+++ b/src/test/test_connected_component_finder.cpp
@@ -37,7 +37,7 @@ int main(){
 
     HashGraph graph;
     IncrementalIdMap<string> id_map;
-    Overlaps overlaps(graph);
+    Overlaps overlaps;
 
     gfa_to_handle_graph(graph, id_map, overlaps, absolute_gfa_path);
 
@@ -79,8 +79,9 @@ int main(){
 
     vector<HashGraph> connected_component_graphs;
     vector <IncrementalIdMap<string> > connected_component_ids;
+    vector<Overlaps> connected_component_overlaps;
 
-    split_connected_components(graph, id_map, connected_component_graphs, connected_component_ids);
+    split_connected_components(graph, id_map, overlaps, connected_component_graphs, connected_component_ids, connected_component_overlaps);
 
     for (size_t i=0; i<connected_component_graphs.size(); i++) {
         plot_graph(connected_component_graphs[i], "component_" + to_string(i));

--- a/src/test/test_hamiltonian_chainer.cpp
+++ b/src/test/test_hamiltonian_chainer.cpp
@@ -122,6 +122,7 @@ void run_test(string& data_file,
     sort(correct_phase_handle_paths.begin(), correct_phase_handle_paths.end());
     
     HamiltonianChainer chainer;
+    chainer.min_haploid_proportion = 0.0; // we don't want this heuristic for these tests
     chainer.generate_chain_paths(graph, id_map, contact_graph);
     
     vector<vector<handle_t>> identified_phase_handle_paths;
@@ -301,6 +302,8 @@ int main(){
             {{"n", false}, {"p", false}, {"q", false}, {"s", false}},
             {{"g_b", false}, {"i", false}, {"j", false}, {"l", false}, {"m", false}, {"o", false}, {"p", false}, {"r", false}, {"t", false}},
             {{"a2", false}, {"b2", false}, {"d2", false}, {"f2", false}},
+            {{"g2", false}},
+            {{"g2", false}},
             {{"h2", false}, {"j2", false}, {"x2", false}},
             {{"a2", false}, {"c2", false}, {"d2", false}, {"e2", false}},
             {{"i2", false}, {"j2", false}, {"x2", false}},

--- a/src/test/test_hamiltonian_chainer.cpp
+++ b/src/test/test_hamiltonian_chainer.cpp
@@ -47,7 +47,7 @@ void run_test(string& data_file,
     
     HashGraph graph;
     IncrementalIdMap<string> id_map;
-    Overlaps overlaps(graph);
+    Overlaps overlaps;
     
     gfa_to_handle_graph(graph, id_map, overlaps, absolute_gfa_path);
     

--- a/src/test/test_hamiltonian_chainer.cpp
+++ b/src/test/test_hamiltonian_chainer.cpp
@@ -47,8 +47,9 @@ void run_test(string& data_file,
     
     HashGraph graph;
     IncrementalIdMap<string> id_map;
+    Overlaps overlaps(graph);
     
-    gfa_to_handle_graph(graph, id_map, absolute_gfa_path);
+    gfa_to_handle_graph(graph, id_map, overlaps, absolute_gfa_path);
     
 //    cerr << "node ID translation:" << endl;
 //    graph.for_each_handle([&](const handle_t& handle) {

--- a/src/test/test_hamiltonian_path.cpp
+++ b/src/test/test_hamiltonian_path.cpp
@@ -62,7 +62,7 @@ void run_test(string& data_file,
     
     HashGraph graph;
     IncrementalIdMap<string> id_map;
-    Overlaps overlaps(graph);
+    Overlaps overlaps;
     
     gfa_to_handle_graph(graph, id_map, overlaps, absolute_gfa_path);
     

--- a/src/test/test_hamiltonian_path.cpp
+++ b/src/test/test_hamiltonian_path.cpp
@@ -62,8 +62,9 @@ void run_test(string& data_file,
     
     HashGraph graph;
     IncrementalIdMap<string> id_map;
+    Overlaps overlaps(graph);
     
-    gfa_to_handle_graph(graph, id_map, absolute_gfa_path);
+    gfa_to_handle_graph(graph, id_map, overlaps, absolute_gfa_path);
     
     
     unordered_set<nid_t> target_nodes, prohibited_nodes;

--- a/src/test/test_kmer_unordered_set.cpp
+++ b/src/test/test_kmer_unordered_set.cpp
@@ -55,8 +55,9 @@ int main() {
 
     HashGraph graph;
     IncrementalIdMap<string> id_map;
+    Overlaps overlaps(graph);
 
-    gfa_to_handle_graph(graph, id_map, absolute_gfa_path);
+    gfa_to_handle_graph(graph, id_map, overlaps, absolute_gfa_path);
 
 
 }

--- a/src/test/test_kmer_unordered_set.cpp
+++ b/src/test/test_kmer_unordered_set.cpp
@@ -55,7 +55,7 @@ int main() {
 
     HashGraph graph;
     IncrementalIdMap<string> id_map;
-    Overlaps overlaps(graph);
+    Overlaps overlaps;
 
     gfa_to_handle_graph(graph, id_map, overlaps, absolute_gfa_path);
 

--- a/src/test/test_kmer_unordered_set.cpp
+++ b/src/test/test_kmer_unordered_set.cpp
@@ -12,7 +12,7 @@ using bdsg::HashGraph;
 int main() {
     // Set up this file path for getting the file from the data folder
     path script_path = __FILE__;
-    path project_directory = script_path.parent_path().parent_path(); // this path is different than the one ryan uses in GfaReader and I'm not sure why
+    path project_directory = script_path.parent_path().parent_path().parent_path(); // this path is different than the one ryan uses in GfaReader and I'm not sure why
 
     // Get test parent1 kmers
     path relative_hap1_kmer_list_path = "data/hg03.all.homo.unique.kmer.1000.fa";

--- a/src/test/test_libsnarls.cpp
+++ b/src/test/test_libsnarls.cpp
@@ -42,8 +42,9 @@ int main(){
 
     HashGraph graph;
     IncrementalIdMap<string> id_map;
+    Overlaps overlaps(graph);
 
-    gfa_to_handle_graph(graph, id_map, absolute_gfa_path);
+    gfa_to_handle_graph(graph, id_map, overlaps, absolute_gfa_path);
 
     plot_graph(graph, "start_graph");
 

--- a/src/test/test_libsnarls.cpp
+++ b/src/test/test_libsnarls.cpp
@@ -42,7 +42,7 @@ int main(){
 
     HashGraph graph;
     IncrementalIdMap<string> id_map;
-    Overlaps overlaps(graph);
+    Overlaps overlaps;
 
     gfa_to_handle_graph(graph, id_map, overlaps, absolute_gfa_path);
 

--- a/src/test/test_overlaps.cpp
+++ b/src/test/test_overlaps.cpp
@@ -1,0 +1,264 @@
+#include "Overlaps.hpp"
+#include "Filesystem.hpp"
+#include "gfa_to_handle.hpp"
+#include "handle_to_gfa.hpp"
+#include "graph_utility.hpp"
+#include "IncrementalIdMap.hpp"
+
+#include "bdsg/hash_graph.hpp"
+#include "handlegraph/util.hpp"
+
+#include <iostream>
+#include <string>
+#include <vector>
+#include <utility>
+#include <cassert>
+#include <sstream>
+#include <algorithm>
+#include <map>
+
+using namespace std;
+
+using ghc::filesystem::path;
+using bdsg::HashGraph;
+using handlegraph::handle_t;
+using handlegraph::nid_t;
+
+int ref_len(vector<pair<int, char>>& correct) {
+    int l = 0;
+    for (auto p : correct) {
+        if (p.second != 'I') {
+            l += p.first;
+        }
+    }
+    return l;
+}
+int query_len(vector<pair<int, char>>& correct) {
+    int l = 0;
+    for (auto p : correct) {
+        if (p.second != 'D') {
+            l += p.first;
+        }
+    }
+    return l;
+}
+
+vector<pair<int, char>> reverse_ops(vector<pair<int, char>>& correct) {
+    auto reversed = correct;
+    reverse(reversed.begin(), reversed.end());
+    for (auto& p : reversed) {
+        if (p.second == 'I') {
+            p.second = 'D';
+        }
+        else if (p.second == 'D') {
+            p.second = 'I';
+        }
+    }
+    return reversed;
+}
+
+void test_cigar_internal(Cigar& cigar, vector<pair<int, char>>& correct) {
+    
+    bool pass = true;
+    pass &= (cigar.empty() == correct.empty());
+    pass &= (cigar.size() == correct.size());
+    auto lens = cigar.aligned_length();
+    pass &= (lens.first == ref_len(correct));
+    pass &= (lens.second == query_len(correct));
+    for (size_t i = 0; i < cigar.size(); ++i) {
+        pass &= (cigar.at(i).type() == correct[i].second);
+        pass &= (cigar.at(i).length() == correct[i].first);
+    }
+    
+    if (cigar.empty()) {
+        pass &= (cigar.get_string() == "0M");
+    }
+    else {
+        stringstream s;
+        for (auto p : correct) {
+            s << p.first << p.second;
+        }
+        pass &= (cigar.get_string() == s.str());
+    }
+    
+    if (!pass) {
+        cerr << "cigar test fail on correct CIGAR ";
+        for (auto o : correct) {
+            cerr << o.first << o.second;
+        }
+        cerr << endl;
+        cerr << "got CIGAR ";
+        for (auto o : cigar) {
+            cerr << o.length() << o.type();
+        }
+        cerr << endl;
+        assert(false);
+    }
+}
+
+void test_cigar(string& cigar_str, vector<pair<int, char>>& correct) {
+    
+    Cigar cigar(cigar_str);
+    Cigar rev_cigar = cigar.reverse();
+    auto rev_correct = reverse_ops(correct);
+    test_cigar_internal(cigar, correct);
+    test_cigar_internal(rev_cigar, rev_correct);
+}
+
+void test_gfa_overlaps_internal(HashGraph& graph, IncrementalIdMap<string>& id_map, Overlaps& overlaps,
+                               vector<tuple<string, bool, string, bool, vector<pair<int, char>>>>& correct) {
+    
+    map<tuple<string, bool, string, bool>, vector<pair<int, char>>> answers;
+    for (auto& r : correct) {
+        answers[make_tuple(get<0>(r), get<1>(r), get<2>(r), get<3>(r))] = get<4>(r);
+        answers[make_tuple(get<2>(r), !get<3>(r), get<0>(r), !get<1>(r))] = reverse_ops(get<4>(r));
+    }
+    
+    assert(overlaps.is_blunt() == answers.empty());
+    
+    graph.for_each_edge([&](const edge_t& edge) {
+        for (auto e : {edge, edge_t(graph.flip(edge.second), graph.flip(edge.first))}) {
+            
+            auto key = make_tuple(id_map.get_name(graph.get_id(e.first)),
+                                  graph.get_is_reverse(e.first),
+                                  id_map.get_name(graph.get_id(e.second)),
+                                  graph.get_is_reverse(e.second));
+            
+            assert(overlaps.has_overlap(graph, e.first, e.second) == (bool) answers.count(key));
+            
+            auto cigar = overlaps.get_overlap(graph, e.first, e.second);
+            if (answers.count(key)) {
+                test_cigar_internal(cigar, answers.at(key));
+            }
+            else {
+                vector<pair<int, char>> c;
+                test_cigar_internal(cigar, c);
+            }
+        }
+    });
+    
+    if (!correct.empty()) {
+        // test remove
+        auto r = correct.back();
+        correct.pop_back();
+        overlaps.remove_overlap(graph,
+                                graph.get_handle(id_map.get_id(get<0>(r)), get<1>(r)),
+                                graph.get_handle(id_map.get_id(get<2>(r)), get<3>(r)));
+        
+        test_gfa_overlaps_internal(graph, id_map, overlaps, correct);
+    }
+}
+
+
+void parse_gfa(string& data_file,
+               HashGraph& graph,
+               IncrementalIdMap<string>& id_map,
+               Overlaps& overlaps) {
+
+    path script_path = __FILE__;
+    path project_directory = script_path.parent_path().parent_path().parent_path();
+    path relative_gfa_path = data_file;
+    path absolute_gfa_path = project_directory / relative_gfa_path;
+    
+    gfa_to_handle_graph(graph, id_map, overlaps, absolute_gfa_path);
+}
+
+void test_gfa_overlaps(string& data_file,
+                       vector<tuple<string, bool, string, bool, vector<pair<int, char>>>>& correct) {
+    
+    HashGraph graph;
+    IncrementalIdMap<string> id_map;
+    Overlaps overlaps;
+    
+    parse_gfa(data_file, graph, id_map, overlaps);
+    
+    test_gfa_overlaps_internal(graph, id_map, overlaps, correct);
+}
+
+int main(){
+
+    // cigar tests
+    {
+        string cigar = "2D5M9I";
+        vector<pair<int, char>> correct{
+            {2, 'D'},
+            {5, 'M'},
+            {9, 'I'}
+        };
+        test_cigar(cigar, correct);
+    }
+    {
+        string cigar = "5M1D3I6X1=";
+        vector<pair<int, char>> correct{
+            {5, 'M'},
+            {1, 'D'},
+            {3, 'I'},
+            {6, 'X'},
+            {1, '='}
+        };
+        test_cigar(cigar, correct);
+    }
+    {
+        string cigar = "0M";
+        vector<pair<int, char>> correct;
+        test_cigar(cigar, correct);
+    }
+    {
+        string cigar = "*";
+        vector<pair<int, char>> correct;
+        test_cigar(cigar, correct);
+    }
+    cerr << "Passed CIGAR tests!" << endl;
+    
+    // overlap tests
+    {
+        string file = "data/simple_chain.gfa";
+        vector<tuple<string, bool, string, bool, vector<pair<int, char>>>> correct{
+            
+        };
+        test_gfa_overlaps(file, correct);
+    }
+    {
+        string file = "data/test_gfa1.gfa";
+        vector<tuple<string, bool, string, bool, vector<pair<int, char>>>> correct{
+            {"11", false, "12", true, {{4, 'M'}}},
+            {"12", true, "13", false, {{5, 'M'}}},
+            {"11", false, "13", false, {{3, 'M'}}}
+        };
+        test_gfa_overlaps(file, correct);
+    }
+    
+    {
+        HashGraph graph;
+        IncrementalIdMap<string> id_map;
+        Overlaps overlaps;
+        
+        string data_file = "data/test_gfa1.gfa";
+        parse_gfa(data_file, graph, id_map, overlaps);\
+        
+        unzip(graph, id_map, overlaps);
+        
+        bool pass = true;
+        pass &= (graph.get_node_count() == 1);
+        graph.for_each_handle([&](const handle_t& h) {
+            // one of the two orientations
+            pass &= (graph.get_sequence(h) == "AATCAAGGT" || graph.get_sequence(h) == "ACCTTGATT");
+        });
+        if (!pass) {
+            cerr << "unzip with stitching test fail, got:\n";
+            graph.for_each_handle([&](const handle_t& h) {
+                cerr << graph.get_id(h) << " " << graph.get_sequence(h) << endl;
+                graph.follow_edges(h, true, [&](const handle_t& p) {
+                    cerr << '\t' << graph.get_id(p) << " " << graph.get_is_reverse(p) << " <-" << endl;
+                });
+                graph.follow_edges(h, false, [&](const handle_t& p) {
+                    cerr << "\t-> " << graph.get_id(p) << " " << graph.get_is_reverse(p) << endl;
+                });
+            });
+            assert(false);
+        }
+    }
+    
+    cerr << "All tests passed!" << endl;
+    return 0;
+}

--- a/src/test/test_rechain.cpp
+++ b/src/test/test_rechain.cpp
@@ -130,7 +130,7 @@ int main(int argc, char** argv){
     
     IncrementalIdMap<string> id_map;
     HashGraph graph;
-    Overlaps overlaps(graph);
+    Overlaps overlaps;
     gfa_to_handle_graph(graph, id_map, overlaps, gfa_path, false, true);
     
     MultiContactGraph contact_graph;

--- a/src/test/test_rechain.cpp
+++ b/src/test/test_rechain.cpp
@@ -130,7 +130,8 @@ int main(int argc, char** argv){
     
     IncrementalIdMap<string> id_map;
     HashGraph graph;
-    gfa_to_handle_graph(graph, id_map, gfa_path, false, true);
+    Overlaps overlaps(graph);
+    gfa_to_handle_graph(graph, id_map, overlaps, gfa_path, false, true);
     
     MultiContactGraph contact_graph;
     


### PR DESCRIPTION
The current unzipping algorithm naively trusts overlaps without checking them for mutual consistency, and it arbitrarily chooses one sequence or the other in the case of mismatches. This could be improved in the future, but I think this gets us off the ground.

This turned out to be a major refactor because overlaps were not currently being tracked. In essence, I changed the basic data type from `HashGraph` + `IncrementalIdMap` to `HashGraph` + `IncrementalIdMap` + `Overlaps`. This required me to touch most modules to ensure that the data was making it around everywhere that it might be needed.

Now that everything is in place, it should be relatively easy to modify the `unzip` algorithm to improve the consensus process if we decide that it's important.