### PR TITLE
Produce correct phased FASTA files when using the default chaining algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Tool for phasing genomic graph data using parental or proximity ligation data.
   - PoreC tested and working
   - WDL is online and can be used to automate the alignment + phasing steps! See below
   - Custom contact maps (as a CSV) are now accepted as input as an optional alternative to BAM
-  - :construction: WARNING: we have encountered [a bug](https://github.com/rlorigro/GFAse/issues/23) in the main branch involving the default chainer, if you are running GFAse please consider invoking `--use_simple_chainer` until we resolve this, simple_chainer is the method used in our publication
 
 ## Automated workflow
 

--- a/inc/HamiltonianChainer.hpp
+++ b/inc/HamiltonianChainer.hpp
@@ -55,6 +55,10 @@ private:
     
     // keep track of which of the paths are the phase paths we added
     array<unordered_set<path_handle_t>, 2> phase_paths;
+    // the names of the phase paths so that we still have a way of accessing them after the
+    // unzip algorithm destroys the path handles
+    // TODO: ugly
+    array<unordered_set<string>, 2> phase_path_names;
     // we remember the graph so that we can use some of its in-built indexes in the public inferface
     // TODO: ugly solution
     const PathHandleGraph* path_graph = nullptr;

--- a/src/HamiltonianChainer.cpp
+++ b/src/HamiltonianChainer.cpp
@@ -68,22 +68,14 @@ struct ChainableComponent {
 };
 
 bool HamiltonianChainer::has_phase_chain(const string& name) const {
-    if (!path_graph || !path_graph->has_path(name)) {
-        return false;
-    }
-    path_handle_t path_handle = path_graph->get_path_handle(name);
-    return (phase_paths[0].count(path_handle) || phase_paths[1].count(path_handle));
+    return (phase_path_names[0].count(name) || phase_path_names[1].count(name));
 }
 
 int8_t HamiltonianChainer::get_partition(const string& name) const {
-    if (!path_graph || !path_graph->has_path(name)) {
-        return 0;
-    }
-    path_handle_t path_handle = path_graph->get_path_handle(name);
-    if (phase_paths[0].count(path_handle)) {
+    if (phase_path_names[0].count(name)) {
         return -1;
     }
-    else if (phase_paths[1].count(path_handle)) {
+    else if (phase_path_names[1].count(name)) {
         return 1;
     }
     else {
@@ -876,6 +868,15 @@ void HamiltonianChainer::generate_chain_paths(MutablePathDeletableHandleGraph& g
     
     // self loops are ambiguous, so we don't allow them in phased paths
     break_self_looping_phase_paths(graph, next_path_ids);
+    
+    // record the names so that we can maintain the public interface TODO: super ugly
+    for (int hap : {0, 1}) {
+        auto& handles = phase_paths[hap];
+        auto& names = phase_path_names[hap];
+        for (auto p : handles) {
+            names.insert(graph.get_path_name(p));
+        }
+    }
     
     if (debug) {
         cerr << "final phase paths:" << endl;


### PR DESCRIPTION
The FASTA output for the Hamiltonian chaining algorithm was pretty badly broken. The root cause was that we used the chainer's collection of path handles to identify which nodes should go into the two haplotype FASTAs. However, these path handles were invalidated by the GFA unzipping algorithm, which destroys the old paths to make new ones consisting only of the unzipped node. The hand-off between these phases of the algorithm is now implemented in terms of the path names instead of path handles, since these remain stable.

This fix works as a patch, but IMO it would be better if we refactored things so that the chainer's memory wasn't needed for the FASTA-writing phase. The current implementation is pretty ugly and opaque. 

Resolves https://github.com/rlorigro/GFAse/issues/23